### PR TITLE
Style external listing links

### DIFF
--- a/style.css
+++ b/style.css
@@ -912,35 +912,6 @@ footer {
   flex-shrink: 0;
 }
 
-/* Chips + map */
-.chips { 
-  display: flex; 
-  flex-wrap: wrap; 
-  gap: 0.75rem; 
-  justify-content: center; 
-  margin: 1rem auto; 
-}
-
-.chip {
-  background: linear-gradient(135deg, #ffffff 0%, #f9fafb 100%);
-  border: 1px solid #e5e7eb;
-  border-radius: 20px;
-  padding: 0.5rem 1rem;
-  font-size: 0.9rem;
-  font-weight: 500;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.06);
-  transition: all 0.3s ease;
-  text-decoration: none;
-  color: #222;
-}
-
-.chip:hover {
-  background: linear-gradient(135deg, #f3f4f6 0%, #e5e7eb 100%);
-  border-color: #d1d5db;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 8px rgba(0,0,0,0.12);
-  color: #ff6f61;
-}
 .map-wrap { max-width: 920px; margin: 0 auto; }
 .map-wrap iframe { width: 100%; height: 360px; border: 0; border-radius: 8px; }
 
@@ -1102,41 +1073,15 @@ footer {
 
 
 /* Share bar */
-.share-bar { 
-  display: flex; 
-  gap: 0.75rem; 
-  justify-content: center; 
-  margin-top: 1rem; 
+.share-bar {
+  display: flex;
   flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  margin-top: 1rem;
 }
 
-.share-btn { 
-  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
-  color: #222;
-  border: 1px solid #d6d6e7;
-  padding: 0.6rem 1rem;
-  border-radius: 8px;
-  font-weight: 600;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.08);
-  transition: all 0.3s ease;
-  cursor: pointer;
-  font-family: inherit;
-  font-size: 0.9rem;
-  position: relative;
-  overflow: hidden;
-}
-
-.share-btn:hover { 
-  background: linear-gradient(135deg, #f1f5f9 0%, #e2e8f0 100%);
-  border-color: #cbd5e1;
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-}
-
-.share-btn:active {
-  transform: translateY(0);
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-}
+/* (Share button styles moved further down to keep overrides together.) */
 
 /* Gallery accordion */
 .gallery-accordion { max-width: 1100px; margin: 0 auto; }
@@ -1620,23 +1565,34 @@ footer {
   flex-wrap: wrap;
 }
 
+
+
 .share-btn {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 1rem;
-  background: rgba(255, 255, 255, 0.1);
-  color: white;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 25px;
-  font-size: 0.85rem;
-  cursor: pointer;
+  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
+  color: #222;
+  border: 1px solid #d6d6e7;
+  padding: 0.6rem 1rem;
+  border-radius: 8px;
+  font-weight: 600;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.08);
   transition: all 0.3s ease;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.9rem;
+  position: relative;
+  overflow: hidden;
 }
 
 .share-btn:hover {
-  background: rgba(255, 255, 255, 0.2);
-  transform: translateY(-1px);
+  background: linear-gradient(135deg, #f1f5f9 0%, #e2e8f0 100%);
+  border-color: #cbd5e1;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+
+.share-btn:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
 .share-icon {
@@ -1653,34 +1609,34 @@ footer {
   flex-wrap: wrap;
 }
 
+
+
 .chip {
   display: flex;
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem 1rem;
-  background: rgba(255, 255, 255, 0.1);
-  color: white;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 25px;
+  background: #4b5563;
+  color: #fff;
+  border: 1px solid #374151;
+  border-radius: 8px;
   text-decoration: none;
-  font-size: 0.85rem;
-  transition: all 0.3s ease;
+  font-size: 0.9rem;
+  transition: background 0.3s ease, transform 0.1s ease;
   cursor: pointer;
 }
 
 .chip:hover {
-  background: rgba(255, 255, 255, 0.2);
+  background: #374151;
   transform: translateY(-1px);
 }
 
 .chip-featured {
-  background: linear-gradient(135deg, #ff6f61, #e55a2b);
-  border-color: transparent;
+  font-weight: 600;
 }
 
 .chip-action {
-  background: rgba(44, 85, 48, 0.8);
-  border-color: #4a7c59;
+  font-weight: 600;
 }
 
 .chip-icon {


### PR DESCRIPTION
## Summary
- Restore original gradient styling for share buttons
- Style S1homes and What3Words links with dark slate buttons and hover lift

## Testing
- `npm test` *(fails: MEDIA_BASE_URL not set)*
- `npm run test:e2e` *(fails: Playwright browsers missing, 29 failed)*

------
https://chatgpt.com/codex/tasks/task_b_68c174bcb8f08324a4e79f77f8c5195c