### PR TITLE
feat: add interactive gallery

### DIFF
--- a/src/components/GalleryIsland.tsx
+++ b/src/components/GalleryIsland.tsx
@@ -1,5 +1,46 @@
-import React from 'react';
+import React, { useState } from 'react';
+import type { ImageMetadata } from 'astro:assets';
+import { Image } from 'astro:assets';
+import LightboxDialog from './LightboxDialog';
 
-export default function GalleryIsland() {
-  return <div>Gallery placeholder</div>;
+interface GalleryIslandProps {
+  images: ImageMetadata[];
+}
+
+export default function GalleryIsland({ images }: GalleryIslandProps) {
+  const [open, setOpen] = useState(false);
+  const [index, setIndex] = useState(0);
+
+  const openAt = (i: number) => {
+    setIndex(i);
+    setOpen(true);
+  };
+
+  const close = () => setOpen(false);
+  const next = () => setIndex((i) => (i + 1) % images.length);
+  const prev = () => setIndex((i) => (i - 1 + images.length) % images.length);
+
+  return (
+    <>
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+        {images.map((img, i) => (
+          <button
+            key={i}
+            onClick={() => openAt(i)}
+            className="focus:outline-none"
+          >
+            <Image src={img} alt={`Gallery image ${i + 1}`} className="w-full h-full object-cover" />
+          </button>
+        ))}
+      </div>
+      <LightboxDialog
+        images={images}
+        index={index}
+        open={open}
+        onClose={close}
+        onPrev={prev}
+        onNext={next}
+      />
+    </>
+  );
 }

--- a/src/components/LightboxDialog.tsx
+++ b/src/components/LightboxDialog.tsx
@@ -1,5 +1,113 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import type { ImageMetadata } from 'astro:assets';
+import { Image } from 'astro:assets';
 
-export default function LightboxDialog() {
-  return <div role="dialog">Lightbox placeholder</div>;
+interface LightboxProps {
+  images: ImageMetadata[];
+  index: number;
+  open: boolean;
+  onClose: () => void;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+export default function LightboxDialog({
+  images,
+  index,
+  open,
+  onClose,
+  onPrev,
+  onNext,
+}: LightboxProps) {
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const prevRef = useRef<HTMLButtonElement>(null);
+  const nextRef = useRef<HTMLButtonElement>(null);
+  const touchStartX = useRef<number>();
+
+  useEffect(() => {
+    if (!open) return;
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    closeRef.current?.focus();
+
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+      if (e.key === 'ArrowLeft') onPrev();
+      if (e.key === 'ArrowRight') onNext();
+      if (e.key === 'Tab') {
+        const focusable = [closeRef.current, prevRef.current, nextRef.current].filter(Boolean) as HTMLElement[];
+        if (focusable.length === 0) return;
+        const idx = focusable.indexOf(document.activeElement as HTMLElement);
+        e.preventDefault();
+        let nextIndex = e.shiftKey ? idx - 1 : idx + 1;
+        if (nextIndex < 0) nextIndex = focusable.length - 1;
+        if (nextIndex >= focusable.length) nextIndex = 0;
+        focusable[nextIndex].focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('keydown', handleKey);
+      previouslyFocused?.focus();
+    };
+  }, [open, onClose, onPrev, onNext]);
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+  };
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    const start = touchStartX.current;
+    if (start == null) return;
+    const diff = e.changedTouches[0].clientX - start;
+    if (Math.abs(diff) > 50) {
+      diff > 0 ? onPrev() : onNext();
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/80 flex items-center justify-center z-50"
+      onClick={onClose}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+    >
+      <div
+        className="relative max-w-[90%] max-h-[90%]"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Image src={images[index]} alt={`Image ${index + 1}`} className="max-h-[90vh] w-auto" />
+        <button
+          ref={closeRef}
+          aria-label="Close"
+          className="absolute top-2 right-2 text-white text-2xl"
+          onClick={onClose}
+        >
+          ×
+        </button>
+        {images.length > 1 && (
+          <>
+            <button
+              ref={prevRef}
+              aria-label="Previous"
+              className="absolute left-2 top-1/2 -translate-y-1/2 text-white text-2xl"
+              onClick={onPrev}
+            >
+              ‹
+            </button>
+            <button
+              ref={nextRef}
+              aria-label="Next"
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-white text-2xl"
+              onClick={onNext}
+            >
+              ›
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,33 +1,22 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import home from '../../content/home.md';
-<<<<<<< HEAD
-
-=======
->>>>>>> codex/rebuild-apple-cottage-website-with-astro
 import highlights from '../../content/highlights.md';
 import faq from '../../content/faq.md';
 import Hero from '../components/Hero.astro';
 import HighlightCards from '../components/HighlightCards.astro';
 import ContactFormIsland from '../components/ContactFormIsland.tsx';
 import FAQ from '../components/FAQ.astro';
-<<<<<<< HEAD
-
-=======
 import MapEmbed from '../components/MapEmbed.astro';
 import DocumentList from '../components/DocumentList.astro';
 import site from '../../site.config';
----
->>>>>>> codex/rebuild-apple-cottage-website-with-astro
-<BaseLayout title={home.frontmatter.title} description={home.frontmatter.description}>
-  <Hero />
-  <section class="prose mx-auto p-4">
-    <home.Content />
-  </section>
-  <HighlightCards items={highlights.frontmatter.items} />
-import MapEmbed from '../components/MapEmbed.astro';
-import DocumentList from '../components/DocumentList.astro';
-import site from '../../site.config';
+import GalleryIsland from '../components/GalleryIsland.tsx';
+import interior1 from '../../locations/interior-1.jpg';
+import interior2 from '../../locations/interior-2.jpg';
+import interior3 from '../../locations/interior-3.jpg';
+import interior4 from '../../locations/interior-4.jpg';
+import interior5 from '../../locations/interior-5.jpg';
+const images = [interior1, interior2, interior3, interior4, interior5];
 ---
 <BaseLayout title={home.frontmatter.title} description={home.frontmatter.description}>
   <Hero />
@@ -35,6 +24,7 @@ import site from '../../site.config';
     <home.Content />
   </section>
   <HighlightCards items={highlights.frontmatter.items} />
+  <GalleryIsland client:load images={images} />
   <MapEmbed />
   <section id="contact" class="p-4 max-w-lg mx-auto">
     <h2 class="text-2xl font-semibold mb-4">Book a Viewing</h2>
@@ -43,4 +33,3 @@ import site from '../../site.config';
   <FAQ items={faq.frontmatter.questions} />
   <DocumentList docs={site.docs} />
 </BaseLayout>
-  <DocumentList docs={site.docs} />


### PR DESCRIPTION
## Summary
- add React-based image gallery and lightbox with keyboard, swipe, and focus management
- wire gallery into homepage with Astro-optimized images

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm test` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c1c820079c8324a97e45c808420fc5