### PR TITLE
Add property details section to homepage

### DIFF
--- a/content/property-details.md
+++ b/content/property-details.md
@@ -1,0 +1,9 @@
+---
+title: "Property Details"
+description: "Learn more about Apple Cottage's features and specifications."
+---
+
+Apple Cottage combines traditional charm with modern comforts. The spacious rooms, updated fixtures, and scenic surroundings make it a delightful place to call home.
+
+Additional features include a large garden, energy-efficient heating, and easy access to local amenities.
+

--- a/src/components/PropertyDetails.astro
+++ b/src/components/PropertyDetails.astro
@@ -1,0 +1,6 @@
+---
+import details from '../../content/property-details.md';
+---
+<section id="property-details" class="prose mx-auto p-4">
+  <details.Content />
+</section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,32 +1,16 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import home from '../../content/home.md';
-<<<<<<< HEAD
-
-=======
->>>>>>> codex/rebuild-apple-cottage-website-with-astro
 import highlights from '../../content/highlights.md';
 import faq from '../../content/faq.md';
 import Hero from '../components/Hero.astro';
 import HighlightCards from '../components/HighlightCards.astro';
 import ContactFormIsland from '../components/ContactFormIsland.tsx';
 import FAQ from '../components/FAQ.astro';
-<<<<<<< HEAD
-
-=======
 import MapEmbed from '../components/MapEmbed.astro';
 import DocumentList from '../components/DocumentList.astro';
-import site from '../../site.config';
----
->>>>>>> codex/rebuild-apple-cottage-website-with-astro
-<BaseLayout title={home.frontmatter.title} description={home.frontmatter.description}>
-  <Hero />
-  <section class="prose mx-auto p-4">
-    <home.Content />
-  </section>
-  <HighlightCards items={highlights.frontmatter.items} />
-import MapEmbed from '../components/MapEmbed.astro';
-import DocumentList from '../components/DocumentList.astro';
+import FloorplanViewerIsland from '../components/FloorplanViewerIsland.tsx';
+import PropertyDetails from '../components/PropertyDetails.astro';
 import site from '../../site.config';
 ---
 <BaseLayout title={home.frontmatter.title} description={home.frontmatter.description}>
@@ -35,6 +19,11 @@ import site from '../../site.config';
     <home.Content />
   </section>
   <HighlightCards items={highlights.frontmatter.items} />
+  <section id="floorplans" class="p-4">
+    <h2 class="text-2xl font-semibold mb-4">Floor Plans</h2>
+    <FloorplanViewerIsland client:load />
+  </section>
+  <PropertyDetails />
   <MapEmbed />
   <section id="contact" class="p-4 max-w-lg mx-auto">
     <h2 class="text-2xl font-semibold mb-4">Book a Viewing</h2>
@@ -43,4 +32,3 @@ import site from '../../site.config';
   <FAQ items={faq.frontmatter.questions} />
   <DocumentList docs={site.docs} />
 </BaseLayout>
-  <DocumentList docs={site.docs} />


### PR DESCRIPTION
## Summary
- add property details markdown content
- render property details via new component
- display property details below floor plan section on home page

## Testing
- `pnpm run lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_68c1c823b0d483248d0a7753ecd327b6