### PR TITLE
feat: responsive nav and netlify-ready contact form

### DIFF
--- a/src/components/ContactFormIsland.tsx
+++ b/src/components/ContactFormIsland.tsx
@@ -1,12 +1,45 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
+import siteConfig from '../../site.config';
 
 export default function ContactFormIsland() {
   const [submitted, setSubmitted] = useState(false);
+  const startRef = useRef(Date.now());
+  const timeRef = useRef<any>(null);
+  const { phone, email } = siteConfig.contact;
+  const phoneHref = phone.replace(/\s+/g, '');
+  const whatsappHref = `https://wa.me/${phone.replace(/\D/g, '')}`;
+
   if (submitted) {
-    return <p>Thanks for your message!</p>;
+    return (
+      <div>
+        <p>Thanks for your message!</p>
+        <div className="mt-4 flex gap-2">
+          <a href={`tel:${phoneHref}`} className="bg-gray-200 px-3 py-2 rounded">Call</a>
+          <a href={whatsappHref} className="bg-gray-200 px-3 py-2 rounded">WhatsApp</a>
+          <a href={`mailto:${email}`} className="bg-gray-200 px-3 py-2 rounded">Email</a>
+        </div>
+      </div>
+    );
   }
+
   return (
-    <form onSubmit={(e) => { e.preventDefault(); setSubmitted(true); }} className="space-y-4" data-testid="contact-form">
+    <form
+      name="contact"
+      method="POST"
+      data-netlify="true"
+      netlify-honeypot="company"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (timeRef.current) {
+          timeRef.current.value = String(Date.now() - startRef.current);
+        }
+        setSubmitted(true);
+      }}
+      className="space-y-4"
+      data-testid="contact-form"
+    >
+      <input type="hidden" name="form-name" value="contact" />
+      <input type="hidden" name="timeToComplete" ref={timeRef} />
       <div>
         <label htmlFor="name" className="block text-sm font-medium">Name</label>
         <input id="name" name="name" type="text" className="mt-1 block w-full border rounded p-2" required />
@@ -20,6 +53,11 @@ export default function ContactFormIsland() {
         <input id="company" name="company" type="text" />
       </div>
       <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">Send</button>
+      <div className="flex gap-2">
+        <a href={`tel:${phoneHref}`} className="bg-gray-200 px-3 py-2 rounded">Call</a>
+        <a href={whatsappHref} className="bg-gray-200 px-3 py-2 rounded">WhatsApp</a>
+        <a href={`mailto:${email}`} className="bg-gray-200 px-3 py-2 rounded">Email</a>
+      </div>
     </form>
   );
 }

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,7 +1,7 @@
 ---
 import Nav from './Nav.astro';
 ---
-<header class="bg-white shadow" id="top">
+<header class="bg-white shadow sticky top-0 z-50" id="top">
   <div class="mx-auto max-w-7xl p-4 flex justify-between items-center">
     <a href="/" class="text-xl font-bold">Apple Cottage</a>
     <Nav />

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,6 +1,22 @@
-<nav>
-  <ul class="flex gap-4">
-    <li><a href="#highlights" class="hover:underline">Highlights</a></li>
-    <li><a href="#faq" class="hover:underline">FAQ</a></li>
+<nav class="relative">
+  <button id="nav-toggle" class="p-2 border rounded md:hidden" aria-expanded="false" aria-controls="nav-menu">
+    <span class="sr-only">Toggle navigation</span>
+    <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+    </svg>
+  </button>
+  <ul id="nav-menu" class="hidden flex-col gap-2 mt-2 bg-white border rounded md:flex md:flex-row md:gap-4 md:mt-0 md:border-0 md:bg-transparent">
+    <li><a href="#highlights" class="block px-4 py-2 hover:underline">Highlights</a></li>
+    <li><a href="#faq" class="block px-4 py-2 hover:underline">FAQ</a></li>
   </ul>
 </nav>
+
+<script is:inline>
+  const toggle = document.getElementById('nav-toggle');
+  const menu = document.getElementById('nav-menu');
+  toggle?.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    toggle.setAttribute('aria-expanded', String(!expanded));
+    menu?.classList.toggle('hidden');
+  });
+</script>


### PR DESCRIPTION
## Summary
- add sticky responsive navigation with toggleable mobile menu
- expand contact form with Netlify attributes, time-to-complete tracking, and direct contact links

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_68c1c829d9f083248c57c0bfb89bba36