### PR TITLE
feat: add lightbox gallery

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,21 @@ export default [
   importPlugin.flatConfigs.typescript,
   {
     files: ['**/*.{js,jsx,ts,tsx}'],
-    languageOptions: { parser: tsParser },
+    languageOptions: {
+      parser: tsParser,
+      globals: {
+        window: 'readonly',
+        document: 'readonly',
+        URL: 'readonly',
+        HTMLElement: 'readonly',
+        HTMLInputElement: 'readonly',
+        HTMLDivElement: 'readonly',
+        TouchEvent: 'readonly',
+        WheelEvent: 'readonly',
+        KeyboardEvent: 'readonly',
+        HTMLButtonElement: 'readonly',
+      },
+    },
     plugins: {
   'jsx-a11y': jsxA11y
     }

--- a/src/components/FloorplanViewerIsland.tsx
+++ b/src/components/FloorplanViewerIsland.tsx
@@ -78,7 +78,7 @@ function ZoomablePlan({ plan }: { plan: Plan }) {
       if (lastSegment) {
         filename = lastSegment;
       }
-    } catch (e) {
+    } catch {
       // fallback to 'floorplan'
     }
     link.download = filename;

--- a/src/components/GalleryIsland.tsx
+++ b/src/components/GalleryIsland.tsx
@@ -1,10 +1,13 @@
 import React, { useState } from 'react';
 import type { ImageMetadata } from 'astro:assets';
+// eslint-disable-next-line import/no-unresolved
 import { Image } from 'astro:assets';
 import LightboxDialog from './LightboxDialog';
 
+// Accept an array of image sources which may be string paths or
+// ImageMetadata objects returned from Astro's asset pipeline.
 interface GalleryIslandProps {
-  images: ImageMetadata[];
+  images: (string | ImageMetadata)[];
 }
 
 export default function GalleryIsland({ images }: GalleryIslandProps) {
@@ -22,12 +25,14 @@ export default function GalleryIsland({ images }: GalleryIslandProps) {
 
   return (
     <>
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2" role="list">
         {images.map((img, i) => (
           <button
             key={i}
             onClick={() => openAt(i)}
             className="focus:outline-none"
+            aria-label={`Open image ${i + 1}`}
+            role="listitem"
           >
             <Image src={img} alt={`Gallery image ${i + 1}`} className="w-full h-full object-cover" />
           </button>

--- a/src/components/LightboxDialog.tsx
+++ b/src/components/LightboxDialog.tsx
@@ -1,9 +1,13 @@
 import React, { useEffect, useRef } from 'react';
 import type { ImageMetadata } from 'astro:assets';
+// eslint-disable-next-line import/no-unresolved
 import { Image } from 'astro:assets';
 
+// The lightbox dialog receives the same array of image sources
+// passed to the gallery. Each source can be a string or
+// ImageMetadata object.
 interface LightboxProps {
-  images: ImageMetadata[];
+  images: (string | ImageMetadata)[];
   index: number;
   open: boolean;
   onClose: () => void;
@@ -75,6 +79,8 @@ export default function LightboxDialog({
       onTouchEnd={handleTouchEnd}
     >
       <div
+        role="dialog"
+        aria-modal="true"
         className="relative max-w-[90%] max-h-[90%]"
         onClick={(e) => e.stopPropagation()}
       >

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,6 +24,10 @@ const images = [interior1, interior2, interior3, interior4, interior5];
 
 <BaseLayout title={home.frontmatter.title} description={home.frontmatter.description}>
   <Hero />
+  <section id="gallery" class="p-4">
+    <h2 class="text-2xl font-semibold mb-4">Gallery</h2>
+    <GalleryIsland images={images} client:load />
+  </section>
   <section class="prose mx-auto p-4">
     <home.Content />
 


### PR DESCRIPTION
## Summary
- integrate React lightbox gallery components with swipe, keyboard and focus trapping
- expose gallery on homepage after hero section
- configure ESLint for browser globals and cleanup lint warnings

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_68c1d98cca388324b70f2177568f2acc