### PR TITLE
feat: add responsive header and enhanced contact form

### DIFF
--- a/src/components/ContactFormIsland.tsx
+++ b/src/components/ContactFormIsland.tsx
@@ -1,23 +1,36 @@
 import React, { useRef, useState } from 'react';
 import siteConfig from '../../site.config';
 
+function ContactButtons() {
+  const { phone, email } = siteConfig.contact;
+  const phoneHref = phone.replace(/\s+/g, '');
+  const whatsappHref = `https://wa.me/${phone.replace(/\D/g, '')}`;
+
+  return (
+    <div className="mt-4 flex gap-2">
+      <a href={`tel:${phoneHref}`} className="bg-gray-200 px-3 py-2 rounded">
+        Call
+      </a>
+      <a href={whatsappHref} className="bg-gray-200 px-3 py-2 rounded">
+        WhatsApp
+      </a>
+      <a href={`mailto:${email}`} className="bg-gray-200 px-3 py-2 rounded">
+        Email
+      </a>
+    </div>
+  );
+}
+
 export default function ContactFormIsland() {
   const [submitted, setSubmitted] = useState(false);
   const startRef = useRef(Date.now());
   const timeRef = useRef<HTMLInputElement>(null);
-  const { phone, email } = siteConfig.contact;
-  const phoneHref = phone.replace(/\s+/g, '');
-  const whatsappHref = `https://wa.me/${phone.replace(/\D/g, '')}`;
 
   if (submitted) {
     return (
       <div>
         <p>Thanks for your message!</p>
-        <div className="mt-4 flex gap-2">
-          <a href={`tel:${phoneHref}`} className="bg-gray-200 px-3 py-2 rounded">Call</a>
-          <a href={whatsappHref} className="bg-gray-200 px-3 py-2 rounded">WhatsApp</a>
-          <a href={`mailto:${email}`} className="bg-gray-200 px-3 py-2 rounded">Email</a>
-        </div>
+        <ContactButtons />
       </div>
     );
   }
@@ -27,7 +40,7 @@ export default function ContactFormIsland() {
       name="contact"
       method="POST"
       data-netlify="true"
-      netlify-honeypot="company"
+      data-netlify-honeypot="company"
       onSubmit={(e) => {
         e.preventDefault();
         if (timeRef.current) {
@@ -40,24 +53,39 @@ export default function ContactFormIsland() {
     >
       <input type="hidden" name="form-name" value="contact" />
       <input type="hidden" name="timeToComplete" ref={timeRef} />
-      <div>
-        <label htmlFor="name" className="block text-sm font-medium">Name</label>
-        <input id="name" name="name" type="text" className="mt-1 block w-full border rounded p-2" required />
-      </div>
-      <div>
-        <label htmlFor="email" className="block text-sm font-medium">Email</label>
-        <input id="email" name="email" type="email" className="mt-1 block w-full border rounded p-2" required />
-      </div>
-      <div className="hidden">
+      <p className="hidden">
         <label htmlFor="company">Company</label>
         <input id="company" name="company" type="text" />
+      </p>
+      <div>
+        <label htmlFor="name" className="block text-sm font-medium">
+          Name
+        </label>
+        <input
+          id="name"
+          name="name"
+          type="text"
+          className="mt-1 block w-full border rounded p-2"
+          required
+        />
       </div>
-      <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">Send</button>
-      <div className="flex gap-2">
-        <a href={`tel:${phoneHref}`} className="bg-gray-200 px-3 py-2 rounded">Call</a>
-        <a href={whatsappHref} className="bg-gray-200 px-3 py-2 rounded">WhatsApp</a>
-        <a href={`mailto:${email}`} className="bg-gray-200 px-3 py-2 rounded">Email</a>
+      <div>
+        <label htmlFor="email" className="block text-sm font-medium">
+          Email
+        </label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          className="mt-1 block w-full border rounded p-2"
+          required
+        />
       </div>
+      <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">
+        Send
+      </button>
+      <ContactButtons />
     </form>
   );
 }
+

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,9 +1,0 @@
----
-import Nav from './Nav.astro';
----
-<header class="bg-white shadow sticky top-0 z-50" id="top">
-  <div class="mx-auto max-w-7xl p-4 flex justify-between items-center">
-    <a href="/" class="text-xl font-bold">Apple Cottage</a>
-    <Nav />
-  </div>
-</header>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,15 +1,31 @@
-<nav class="relative">
-  <button id="nav-toggle" class="p-2 border rounded md:hidden" aria-expanded="false" aria-controls="nav-menu">
-    <span class="sr-only">Toggle navigation</span>
-    <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
-    </svg>
-  </button>
-  <ul id="nav-menu" class="hidden flex-col gap-2 mt-2 bg-white border rounded md:flex md:flex-row md:gap-4 md:mt-0 md:border-0 md:bg-transparent">
-    <li><a href="#highlights" class="block px-4 py-2 hover:underline">Highlights</a></li>
-    <li><a href="#faq" class="block px-4 py-2 hover:underline">FAQ</a></li>
-  </ul>
-</nav>
+<header class="sticky top-0 z-50 bg-white shadow">
+  <div class="mx-auto max-w-7xl flex items-center justify-between p-4">
+    <a href="/" class="text-xl font-bold">Apple Cottage</a>
+    <button
+      id="nav-toggle"
+      class="p-2 border rounded md:hidden"
+      aria-expanded="false"
+      aria-controls="nav-menu"
+    >
+      <span class="sr-only">Toggle navigation</span>
+      <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M4 6h16M4 12h16M4 18h16"
+        ></path>
+      </svg>
+    </button>
+    <ul
+      id="nav-menu"
+      class="hidden absolute left-0 right-0 top-full flex-col gap-2 bg-white border-b md:static md:flex md:flex-row md:gap-4 md:border-0"
+    >
+      <li><a href="#highlights" class="block px-4 py-2 hover:underline">Highlights</a></li>
+      <li><a href="#faq" class="block px-4 py-2 hover:underline">FAQ</a></li>
+    </ul>
+  </div>
+</header>
 
 <script is:inline>
   const toggle = document.getElementById('nav-toggle');

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,69 +1,39 @@
 ---
 import '../styles/globals.css';
 import Seo from '../components/Seo.astro';
-<<<<<<< HEAD
-
-=======
->>>>>>> codex/rebuild-apple-cottage-website-with-astro
-import Header from '../components/Header.astro';
+import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
 import site from '../../site.config.ts';
+
 const { title = site.title, description = site.description } = Astro.props;
 const gaId = site.analyticsId;
-<<<<<<< HEAD
-
-const { title = 'Apple Cottage', description = 'Charming home in Creetown' } = Astro.props;
-
-=======
 ---
->>>>>>> codex/rebuild-apple-cottage-website-with-astro
 <!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-<<<<<<< HEAD
+    <Seo {title} {description} />
+    {gaId && (
+      <>
+        <script src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`} defer></script>
+        <script is:inline>
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${gaId}');
+          `}
+        </script>
+      </>
+    )}
+  </head>
+  <body class="min-h-screen antialiased flex flex-col">
+    <Nav />
+    <main class="flex-1">
+      <slot />
+    </main>
+    <Footer />
+  </body>
+</html>
 
-=======
->>>>>>> codex/rebuild-apple-cottage-website-with-astro
-      <Seo {title} {description} />
-      {gaId && (
-        <>
-          <script src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`} defer></script>
-          ---
-          import '../styles/globals.css';
-          import Seo from '../components/Seo.astro';
-          import Header from '../components/Header.astro';
-          import Footer from '../components/Footer.astro';
-          import site from '../../site.config.ts';
-          const { title = site.title, description = site.description } = Astro.props;
-          const gaId = site.analyticsId;
-          ---
-          <!DOCTYPE html>
-          <html lang="en">
-            <head>
-              <meta charset="utf-8" />
-              <meta name="viewport" content="width=device-width, initial-scale=1" />
-              <Seo {title} {description} />
-              {gaId && (
-                <>
-                  <script src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`} defer></script>
-                  <script is:inline>
-                  {`
-                    window.dataLayer = window.dataLayer || [];
-                    function gtag(){dataLayer.push(arguments);}
-                    gtag('js', new Date());
-                    gtag('config', '${gaId}');
-                  `}
-                  </script>
-                </>
-              )}
-            </head>
-            <body class="min-h-screen antialiased flex flex-col">
-              <Header />
-              <main class="flex-1">
-                <slot />
-              </main>
-              <Footer />
-            </body>
-          </html>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -36,4 +36,3 @@ const gaId = site.analyticsId;
     <Footer />
   </body>
 </html>
-


### PR DESCRIPTION
## Summary
- replace header with sticky, responsive navigation and mobile toggle
- add Netlify-enabled contact form with honeypot, time tracking, and quick contact buttons

## Testing
- `pnpm lint` (fails: Unable to resolve path to module 'astro:assets'; no-undef errors)
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_68c1d99212e08324980258000949c3de