### PR TITLE
Update property listing price to £300,000

### DIFF
--- a/site.config.ts
+++ b/site.config.ts
@@ -35,7 +35,7 @@ export const site = {
   address: 'Apple Cottage, Creetown, Scotland',
   coordinates: { lat: 54.9, lng: -4.4 },
   bookingUrl: 'https://tidycal.com/sidmustafa/apple-cottage-viewing',
-  price: '💰 Offers Over £275,000',
+  price: '💰 Offers Over £300,000',
   bedrooms: '🛏️ 3 Double Bedrooms',
   bathrooms: '🛁 1 + Downstairs WC',
   epc: '⚡ B - Energy Efficient',


### PR DESCRIPTION
## Summary
- update the property price in the site configuration to show offers over £300,000

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68c86cc268188324857d86d6a47c3d4a