### PR TITLE
Fix home report links

### DIFF
--- a/site.config.ts
+++ b/site.config.ts
@@ -17,6 +17,7 @@ const OVERRIDES = {
   FLOORPLAN_3D_URL: (import.meta as any).env.FLOORPLAN_3D_URL as string | undefined,
   EPC_IMAGE_URL: (import.meta as any).env.EPC_IMAGE_URL as string | undefined,
   PLOT_IMAGE_URL: (import.meta as any).env.PLOT_IMAGE_URL as string | undefined,
+  HOME_REPORT_URL: (import.meta as any).env.HOME_REPORT_URL as string | undefined,
 };
 function media(path: string) {
   if (!path) return path;
@@ -250,8 +251,8 @@ export const site = {
     s1homes: 'https://s1homes.com/property-for-sale/Detached/20250905090829948'
   },
   docs: [
-    { label: 'Plot Plan', href: OVERRIDES.PLOT_IMAGE_URL || `${DEFAULT_CDN}/docs/plot.png` },
-    { label: 'Home Report', href: `${DEFAULT_CDN}/docs/home-report.pdf` },
+    { label: 'Plot Plan', href: OVERRIDES.PLOT_IMAGE_URL || media('/docs/plot.png') },
+    { label: 'Home Report', href: OVERRIDES.HOME_REPORT_URL || media('/docs/home-report.pdf') },
     { label: 'Planning Permission', href: `${DEFAULT_CDN}/docs/planning-permission.png` }
   ]
 };

--- a/src/components/DocumentList.astro
+++ b/src/components/DocumentList.astro
@@ -5,8 +5,17 @@ const { docs = [] } = Astro.props;
   <div class="container">
     <h2 class="text-2xl font-bold mb-4">Documents</h2>
     <ul class="list-disc ml-4 space-y-2">
-      {docs.map(doc => (
-        <li><a href={doc.href} class="text-blue-600 underline">{doc.label}</a></li>
+      {docs.map((doc) => (
+        <li>
+          <a
+            href={doc.href}
+            class="text-blue-600 underline"
+            target="_blank"
+            rel="noopener"
+          >
+            {doc.label}
+          </a>
+        </li>
       ))}
     </ul>
   </div>


### PR DESCRIPTION
## Summary
- default the Home Report document to the bundled /docs PDF and allow overriding it via an env var so the correct file opens
- ensure document list links open in a new tab with noopener for consistency

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68c86ed1fdb08324b2c04a59de72d32c