### PR TITLE
Remove local screenshot artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ crash.log
 *.tfstate.backup
 crash.log
 test-results/
+# Playwright artifacts produced during E2E runs
+artifacts/
+playwright-report/
 .http-server.pid
 
 # Local Netlify folder


### PR DESCRIPTION
## Summary
- add Playwright artifact directories to `.gitignore` so local screenshots such as `artifacts/after.png` are not tracked

## Testing
- npm run lint
- npm run typecheck
- npm run test
- npm run build
- SITE_URL=http://127.0.0.1:8080 npm run test:e2e *(fails: nav no longer exposes a "Contact" link, and CDN requests for floorplan images are blocked in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_b_68c94b71065083248d0cdbcfcc1daa2d