### PR TITLE
Refresh sticky CTA design

### DIFF
--- a/src/components/StickyCTA.astro
+++ b/src/components/StickyCTA.astro
@@ -1,36 +1,329 @@
 ---
 ---
-<!-- Minimal sticky CTA bar (desktop + mobile) -->
+<!-- Refined sticky CTA bar optimised for mobile + desktop -->
 <style>
-  .sticky-cta { position: fixed; left: 0; right: 0; bottom: 0; background: #fff; border-top: 1px solid #e5e7eb; display:flex; align-items:center; justify-content:space-between; padding:0.5rem 1rem; gap:0.5rem; z-index:1200; }
-  .sticky-cta__left { display:flex; align-items:center; gap:0.5rem; font-weight:600; }
-  .sticky-cta__actions { display:flex; gap:0.5rem; }
-  .btn-primary { background:#0f172a; color:#fff; padding:0.5rem 0.75rem; border-radius:6px; text-decoration:none; }
-  .btn-ghost { background:transparent; border:1px solid #d1d5db; padding:0.45rem 0.6rem; border-radius:6px; text-decoration:none; color:#0f172a; }
-  @media(min-width:900px){ .sticky-cta{ right:auto; left:1rem; bottom:1rem; width:auto; border-radius:10px; box-shadow:0 6px 24px rgba(15,23,42,0.12); } }
+  .sticky-cta {
+    position: fixed;
+    inset: auto 1rem 1.25rem 1rem;
+    z-index: 1200;
+    display: grid;
+    gap: 1rem;
+    padding: 1rem 1.25rem;
+    background: rgba(255, 255, 255, 0.96);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    border-radius: 1.25rem;
+    box-shadow: 0 22px 48px -20px rgba(15, 23, 42, 0.45);
+    backdrop-filter: blur(12px);
+    max-width: min(60rem, calc(100% - 2rem));
+    margin: 0 auto;
+  }
+
+  .sticky-cta__summary {
+    display: grid;
+    gap: 0.25rem;
+  }
+
+  .sticky-cta__headline {
+    margin: 0;
+    font-size: clamp(1rem, 2.6vw, 1.15rem);
+    font-weight: 600;
+    color: #0f172a;
+  }
+
+  .sticky-cta__meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .sticky-cta__price,
+  .sticky-cta__chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.65rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+  }
+
+  .sticky-cta__price {
+    background: rgba(15, 23, 42, 0.08);
+    color: #0f172a;
+  }
+
+  .sticky-cta__chip {
+    background: rgba(13, 148, 136, 0.12);
+    color: #0f766e;
+  }
+
+  .sticky-cta__supporting {
+    margin: 0;
+    font-size: 0.9rem;
+    color: rgba(15, 23, 42, 0.72);
+  }
+
+  .sticky-cta__actions {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  }
+
+  .sticky-cta__button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    border-radius: 999px;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.95rem;
+    letter-spacing: 0.01em;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+    will-change: transform;
+  }
+
+  .sticky-cta__button:focus-visible {
+    outline: 3px solid rgba(59, 130, 246, 0.65);
+    outline-offset: 2px;
+  }
+
+  .sticky-cta__button--primary {
+    background: linear-gradient(135deg, #0f172a 0%, #1e293b 48%, #0f172a 100%);
+    color: #f8fafc;
+    box-shadow: 0 12px 22px -16px rgba(15, 23, 42, 0.8);
+  }
+
+  .sticky-cta__button--secondary {
+    background: #ffffff;
+    color: #0f172a;
+    border: 1px solid rgba(15, 23, 42, 0.15);
+  }
+
+  .sticky-cta__button--whatsapp {
+    background: rgba(37, 211, 102, 0.1);
+    color: #166534;
+    border: 1px solid rgba(37, 211, 102, 0.25);
+  }
+
+  .sticky-cta__button:hover,
+  .sticky-cta__button:focus-visible {
+    transform: translateY(-2px);
+  }
+
+  .sticky-cta__button--primary:hover,
+  .sticky-cta__button--primary:focus-visible {
+    box-shadow: 0 18px 32px -16px rgba(15, 23, 42, 0.88);
+  }
+
+  .sticky-cta__button--secondary:hover,
+  .sticky-cta__button--secondary:focus-visible {
+    background: rgba(15, 23, 42, 0.05);
+  }
+
+  .sticky-cta__button--whatsapp:hover,
+  .sticky-cta__button--whatsapp:focus-visible {
+    background: rgba(37, 211, 102, 0.18);
+  }
+
+  .sticky-cta__icon {
+    display: inline-flex;
+    width: 1.15rem;
+    height: 1.15rem;
+  }
+
+  @media (max-width: 37.5rem) {
+    .sticky-cta {
+      border-radius: 1rem;
+      inset: auto 0 0 0;
+      max-width: none;
+      margin: 0;
+      padding: 1rem;
+      border-left: 0;
+      border-right: 0;
+    }
+  }
+
+  @media (min-width: 56rem) {
+    .sticky-cta {
+      grid-template-columns: 1fr auto;
+      align-items: center;
+    }
+
+    .sticky-cta__actions {
+      grid-template-columns: repeat(3, minmax(0, auto));
+    }
+  }
 </style>
 
-<div class="sticky-cta" role="region" aria-label="Booking sticky call to action">
-  <div class="sticky-cta__left">
-    <span class="price">Offers Over £300,000</span>
-    <span class="chip">EPC B</span>
-  </div>
-    <div class="sticky-cta__actions">
-      <a href="#book-viewing" class="btn-ghost" id="sticky-book">Book Viewing</a>
-      <a href="/docs/home-report.pdf" class="btn-primary" download id="sticky-hr">Download Home Report</a>
-    <!-- Call removed per request; WhatsApp only -->
-    <a href="https://wa.me/447931071401" class="btn-ghost" aria-label="WhatsApp seller" id="sticky-wa">WhatsApp</a>
+<aside
+  class="sticky-cta"
+  role="complementary"
+  aria-labelledby="sticky-cta-heading"
+  aria-live="polite"
+>
+  <div class="sticky-cta__summary">
+    <p class="sticky-cta__headline" id="sticky-cta-heading">
+      Secure your viewing at Apple Cottage today
+    </p>
+    <div class="sticky-cta__meta">
+      <span class="sticky-cta__price" aria-label="Offers over three hundred thousand pounds">
+        Offers Over £300,000
+      </span>
+      <span class="sticky-cta__chip" aria-label="Energy performance certificate rating B">
+        EPC B
+      </span>
     </div>
+    <p class="sticky-cta__supporting">
+      Fresh to market — schedule a tour, download the home report or message the owner instantly.
+    </p>
   </div>
+  <div class="sticky-cta__actions">
+    <a
+      href="#book-viewing"
+      class="sticky-cta__button sticky-cta__button--primary"
+      id="sticky-book"
+    >
+      <span class="sticky-cta__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path
+            d="M4 7C4 5.343 5.343 4 7 4H17C18.657 4 20 5.343 20 7V17C20 18.657 18.657 20 17 20H7C5.343 20 4 18.657 4 17V7Z"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M8 3V5"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M16 3V5"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M8 9H16"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M10 13H14"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </span>
+      Book a Viewing
+    </a>
+    <a
+      href="/docs/home-report.pdf"
+      class="sticky-cta__button sticky-cta__button--secondary"
+      download
+      id="sticky-hr"
+    >
+      <span class="sticky-cta__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path
+            d="M12 3V17"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M7 12L12 17L17 12"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M5 21H19"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </span>
+      Download Home Report
+    </a>
+    <a
+      href="https://wa.me/447931071401"
+      class="sticky-cta__button sticky-cta__button--whatsapp"
+      aria-label="Open WhatsApp chat with the Apple Cottage owner"
+      id="sticky-wa"
+    >
+      <span class="sticky-cta__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path
+            d="M3 20L4.2 16.2C3.4 14.9 3 13.5 3 12C3 7.6 6.6 4 11 4C15.4 4 19 7.6 19 12C19 16.4 15.4 20 11 20C9.6 20 8.2 19.6 7 18.9L3 20Z"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M9.5 9.5C9.5 9.5 9 8 8.5 8C8 8 7 8.2 7 9.8C7 11.4 8.4 13.1 8.6 13.4C8.8 13.7 9.9 15.3 11.6 16C12.6 16.4 13.2 16.4 13.6 16.3C14 16.2 15 15.7 15.1 15.2C15.2 14.7 15.2 14.2 14.9 14C14.6 13.8 13.6 13.3 13.3 13.2C13 13.1 12.7 13.2 12.5 13.5C12.2 13.9 11.8 14.4 11.6 14.3C11.4 14.2 10.5 13.8 9.9 13.2C9.3 12.6 9 11.7 8.9 11.5C8.8 11.3 9.1 11.1 9.3 10.8C9.5 10.5 9.6 10.3 9.7 10.1C9.8 9.9 9.7 9.7 9.6 9.6C9.4 9.4 9.5 9.5 9.5 9.5Z"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </span>
+      WhatsApp Seller
+    </a>
+  </div>
+</aside>
 
-  <script is:inline>
-    (function(){
-      function sendEvent(name){ try{ if(window.gtag) window.gtag('event', name, { event_category: 'engagement', event_label: 'sticky_cta' }); }catch(e){}
+<script is:inline>
+  (function () {
+    function sendEvent(name) {
+      try {
+        if (window?.gtag) {
+          window.gtag('event', name, {
+            event_category: 'engagement',
+            event_label: 'sticky_cta',
+          });
+        }
+      } catch (error) {
+        console.error('Unable to push sticky CTA analytics event', error);
       }
-      var el = document.getElementById('sticky-book'); if(el) el.addEventListener('click', function(){ sendEvent('sticky_book_click'); });
-      var el2 = document.getElementById('sticky-hr'); if(el2) el2.addEventListener('click', function(){ sendEvent('home_report_download'); });
-      var el3 = document.getElementById('sticky-call'); if(el3) el3.addEventListener('click', function(){ sendEvent('call_click'); });
-      var el4 = document.getElementById('sticky-wa'); if(el4) el4.addEventListener('click', function(){ sendEvent('whatsapp_click'); });
-    })();
-  </script>
-</div>
+    }
+
+    var bookButton = document.getElementById('sticky-book');
+    if (bookButton) {
+      bookButton.addEventListener('click', function () {
+        sendEvent('sticky_book_click');
+      });
+    }
+
+    var reportButton = document.getElementById('sticky-hr');
+    if (reportButton) {
+      reportButton.addEventListener('click', function () {
+        sendEvent('home_report_download');
+      });
+    }
+
+    var whatsappButton = document.getElementById('sticky-wa');
+    if (whatsappButton) {
+      whatsappButton.addEventListener('click', function () {
+        sendEvent('whatsapp_click');
+      });
+    }
+  })();
+</script>


### PR DESCRIPTION
## Summary
- redesign the sticky CTA as a marketing-led floating panel with improved hierarchy and messaging
- restructure the layout to use responsive grids, iconography, and accessible roles/labels across screen sizes
- harden analytics wiring with guarded gtag access and error logging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cc537ae7948324a93e526654fb02f1