### PR TITLE
feat: track gallery and tour engagement for install prompt

### DIFF
--- a/src/components/GalleryIsland.tsx
+++ b/src/components/GalleryIsland.tsx
@@ -289,15 +289,29 @@ export default function GalleryIsland({ images }: GalleryIslandProps) {
     else updateUrlParams({ index: null });
   }, [open, index]);
 
-  const openAt = (i: number) => { 
+  const openAt = (i: number) => {
     if (i >= 0 && i < filtered.length && filtered[i]?.src) {
-      setIndex(i); 
-      setOpen(true); 
+      setIndex(i);
+      setOpen(true);
     }
   };
   const close = () => setOpen(false);
   const next = () => setIndex((i) => (i + 1) % filtered.length);
   const prev = () => setIndex((i) => (i - 1 + filtered.length) % filtered.length);
+
+  useEffect(() => {
+    if (!open) return;
+    if (typeof window === 'undefined') return;
+    const current = filtered[index];
+    if (!current || !current.src) return;
+    const detail = {
+      src: current.src,
+      alt: current.alt,
+      index,
+      total: filtered.length,
+    };
+    window.dispatchEvent(new CustomEvent('applecottage:gallery-viewed', { detail }));
+  }, [open, index, filtered]);
 
   // Get icon for filter option
   const getFilterIcon = (filterName: string) => {

--- a/src/components/PanoViewerIsland.tsx
+++ b/src/components/PanoViewerIsland.tsx
@@ -1,5 +1,5 @@
 /* eslint-env browser */
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 type Pano = {
   label?: string;
@@ -12,9 +12,32 @@ interface Props {
   height?: number;
 }
 
+const REPORT_INTERVAL_MS = 5000;
+
 export default function PanoViewerIsland({ pano, height = 320 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [inited, setInited] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+  const initializedRef = useRef(false);
+  const watchIntervalRef = useRef<number | null>(null);
+
+  const dispatchTourWatch = useCallback((seconds: number) => {
+    if (typeof window === 'undefined') return;
+    if (!Number.isFinite(seconds) || seconds <= 0) return;
+    window.dispatchEvent(new CustomEvent('applecottage:tour-watch', {
+      detail: {
+        secondsWatched: seconds,
+        source: 'pannellum',
+        panoSrc: pano.src,
+        label: pano.label,
+      },
+    }));
+  }, [pano.label, pano.src]);
+
+  useEffect(() => {
+    initializedRef.current = false;
+    setInited(false);
+  }, [pano.src]);
 
   useEffect(() => {
     const el = containerRef.current;
@@ -24,7 +47,7 @@ export default function PanoViewerIsland({ pano, height = 320 }: Props) {
     let cleanup: (() => void) | undefined;
 
     const init = async () => {
-      if (inited) return;
+      if (initializedRef.current) return;
       try {
         await Promise.all([
           import('pannellum/build/pannellum.js'),
@@ -57,30 +80,70 @@ export default function PanoViewerIsland({ pano, height = 320 }: Props) {
           try { viewer.destroy && viewer.destroy(); } catch { /* noop */ }
         };
         setInited(true);
+        initializedRef.current = true;
       } catch (err) {
-         
+
         console.error('Failed to init pannellum', err);
       }
     };
 
+    const handleIntersection = (entries: IntersectionObserverEntry[]) => {
+      const entry = entries[0];
+      if (!entry) return;
+      setIsVisible(entry.isIntersecting);
+      if (entry.isIntersecting) {
+        void init();
+      }
+    };
+
     if ('IntersectionObserver' in window) {
-      observer = new IntersectionObserver((entries) => {
-        const entry = entries[0];
-        if (entry && entry.isIntersecting) {
-          observer?.disconnect();
-          init();
-        }
-      }, { rootMargin: '200px' });
+      observer = new IntersectionObserver(handleIntersection, { rootMargin: '200px', threshold: 0.2 });
       observer.observe(el);
     } else {
-      init();
+      setIsVisible(true);
+      void init();
     }
 
     return () => {
       observer?.disconnect();
       cleanup?.();
     };
-  }, [pano.src, inited]);
+  }, [pano.src]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    if (!isVisible || !inited) {
+      if (watchIntervalRef.current !== null) {
+        window.clearInterval(watchIntervalRef.current);
+        watchIntervalRef.current = null;
+      }
+      return;
+    }
+
+    if (watchIntervalRef.current !== null) {
+      return;
+    }
+
+    let lastMark = Date.now();
+    watchIntervalRef.current = window.setInterval(() => {
+      const now = Date.now();
+      const deltaSeconds = Math.max(0, Math.round((now - lastMark) / 1000));
+      lastMark = now;
+      if (deltaSeconds > 0) {
+        dispatchTourWatch(deltaSeconds);
+      }
+    }, REPORT_INTERVAL_MS);
+
+    return () => {
+      if (watchIntervalRef.current !== null) {
+        window.clearInterval(watchIntervalRef.current);
+        watchIntervalRef.current = null;
+      }
+    };
+  }, [dispatchTourWatch, inited, isVisible]);
 
   return (
     <div className="w-full">

--- a/src/components/Simple360Viewer.tsx
+++ b/src/components/Simple360Viewer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 interface Props {
   pano: {
@@ -14,6 +14,21 @@ export default function Simple360Viewer({ pano, height = 320 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+  const watchIntervalRef = useRef<number | null>(null);
+
+  const dispatchTourWatch = useCallback((seconds: number) => {
+    if (typeof window === 'undefined') return;
+    if (!Number.isFinite(seconds) || seconds <= 0) return;
+    window.dispatchEvent(new CustomEvent('applecottage:tour-watch', {
+      detail: {
+        secondsWatched: seconds,
+        source: 'a-frame',
+        panoSrc: pano.src,
+        label: pano.label,
+      },
+    }));
+  }, [pano.label, pano.src]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -49,6 +64,62 @@ export default function Simple360Viewer({ pano, height = 320 }: Props) {
 
     loadAFrame().catch(() => setError(true));
   }, [pano.src]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    if (typeof window === 'undefined' || !('IntersectionObserver' in window)) {
+      setIsVisible(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      const entry = entries[0];
+      setIsVisible(Boolean(entry?.isIntersecting));
+    }, { threshold: 0.25 });
+
+    observer.observe(container);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    if (!loaded || !isVisible) {
+      if (watchIntervalRef.current !== null) {
+        window.clearInterval(watchIntervalRef.current);
+        watchIntervalRef.current = null;
+      }
+      return;
+    }
+
+    if (watchIntervalRef.current !== null) {
+      return;
+    }
+
+    let lastMark = Date.now();
+    watchIntervalRef.current = window.setInterval(() => {
+      const now = Date.now();
+      const deltaSeconds = Math.max(0, Math.round((now - lastMark) / 1000));
+      lastMark = now;
+      if (deltaSeconds > 0) {
+        dispatchTourWatch(deltaSeconds);
+      }
+    }, 5000);
+
+    return () => {
+      if (watchIntervalRef.current !== null) {
+        window.clearInterval(watchIntervalRef.current);
+        watchIntervalRef.current = null;
+      }
+    };
+  }, [dispatchTourWatch, isVisible, loaded]);
 
   if (error) {
     return (

--- a/src/components/VirtualTours.astro
+++ b/src/components/VirtualTours.astro
@@ -80,6 +80,60 @@ import site from '../../site.config';
 </section>
 
 <script>
+  var detachTourWatchListeners = function () {};
+  var lastReportedSeconds = 0;
+  var currentTourMeta = { id: '', label: '' };
+
+  function dispatchTourWatch(seconds) {
+    if (typeof window === 'undefined') return;
+    if (!Number.isFinite(seconds) || seconds <= 0) return;
+    try {
+      window.dispatchEvent(new CustomEvent('applecottage:tour-watch', {
+        detail: {
+          secondsWatched: seconds,
+          source: 'video',
+          tourId: currentTourMeta.id,
+          label: currentTourMeta.label,
+        }
+      }));
+    } catch (error) {
+      console.warn('Unable to dispatch tour watch event', error);
+    }
+  }
+
+  function bindTourWatch(videoEl) {
+    if (!videoEl) return;
+    detachTourWatchListeners();
+    lastReportedSeconds = Math.floor(videoEl.currentTime || 0);
+
+    var handleTimeUpdate = function () {
+      var seconds = Math.floor(videoEl.currentTime || 0);
+      if (seconds > lastReportedSeconds) {
+        var delta = seconds - lastReportedSeconds;
+        lastReportedSeconds = seconds;
+        dispatchTourWatch(delta);
+      }
+    };
+
+    var handleSeeked = function () {
+      lastReportedSeconds = Math.floor(videoEl.currentTime || 0);
+    };
+
+    var handleEnded = function () {
+      handleTimeUpdate();
+    };
+
+    videoEl.addEventListener('timeupdate', handleTimeUpdate);
+    videoEl.addEventListener('seeked', handleSeeked);
+    videoEl.addEventListener('ended', handleEnded);
+
+    detachTourWatchListeners = function () {
+      videoEl.removeEventListener('timeupdate', handleTimeUpdate);
+      videoEl.removeEventListener('seeked', handleSeeked);
+      videoEl.removeEventListener('ended', handleEnded);
+    };
+  }
+
   // Expose functions on window so onclick handlers can find them in prod
   window.openVirtualTour = function(index) {
     const tours = (window.siteConfig && window.siteConfig.virtual360Tours) || [];
@@ -115,8 +169,12 @@ import site from '../../site.config';
     title.textContent = tour.label;
     description.textContent = tour.description;
 
+    var tourId = tour.id || tour.slug || tour.videoMp4 || tour.videoWebm || tour.label || ('tour-' + index);
+    currentTourMeta = { id: String(tourId || ''), label: tour.label || '' };
+
     // Load and show modal
     video.load();
+    bindTourWatch(video);
     modal.classList.remove('hidden');
     document.body.style.overflow = 'hidden';
   };
@@ -124,6 +182,18 @@ import site from '../../site.config';
   window.closeVirtualTour = function() {
     const modal = document.getElementById('virtual-tour-modal');
     const video = document.getElementById('virtual-tour-video');
+
+    if (video) {
+      var seconds = Math.floor(video.currentTime || 0);
+      if (seconds > lastReportedSeconds) {
+        dispatchTourWatch(seconds - lastReportedSeconds);
+        lastReportedSeconds = seconds;
+      }
+    }
+
+    detachTourWatchListeners();
+    lastReportedSeconds = 0;
+    currentTourMeta = { id: '', label: '' };
 
     video.pause();
     modal.classList.add('hidden');

--- a/src/components/a2hs/InstallPromptIsland.tsx
+++ b/src/components/a2hs/InstallPromptIsland.tsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import { useA2HS } from './useA2HS';
+
+export default function InstallPromptIsland(): JSX.Element | null {
+  const {
+    isSupported,
+    canInstall,
+    isPromptVisible,
+    triggerReason,
+    showPrompt,
+    dismissPrompt,
+    registerGalleryView,
+    registerTourWatch,
+    registerOfflineDownload,
+  } = useA2HS();
+
+  const installButtonRef = useRef<HTMLButtonElement>(null);
+
+  const message = useMemo(() => {
+    switch (triggerReason) {
+      case 'gallery':
+        return 'Loved those photos? Add Apple Cottage to your home screen to revisit the gallery anytime.';
+      case 'tour':
+        return 'Enjoying the virtual tour? Install the app for quick, offline-friendly access to every room.';
+      case 'offline':
+        return 'Offline access unlocked — install the app so the full experience is just a tap away.';
+      default:
+        return 'Install Apple Cottage on your device for faster access and offline viewing.';
+    }
+  }, [triggerReason]);
+
+  useEffect(() => {
+    if (!isPromptVisible) return;
+    const id = window.setTimeout(() => {
+      installButtonRef.current?.focus();
+    }, 0);
+    return () => window.clearTimeout(id);
+  }, [isPromptVisible]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const handleGalleryViewed = (event: Event) => {
+      const { detail } = event as CustomEvent<{ id?: string; src?: string; index?: number }>;
+      const identifier = detail?.id ?? detail?.src ?? (typeof detail?.index === 'number' ? `index-${detail.index}` : undefined);
+      if (identifier) {
+        registerGalleryView(String(identifier));
+      }
+    };
+
+    const handleTourWatch = (event: Event) => {
+      const { detail } = event as CustomEvent<{ secondsWatched?: number; seconds?: number; delta?: number }>; // backward compatibility keys
+      const seconds = Number(detail?.secondsWatched ?? detail?.seconds ?? detail?.delta ?? 0);
+      if (Number.isFinite(seconds) && seconds > 0) {
+        registerTourWatch(seconds);
+      }
+    };
+
+    const handleOfflineDownload = () => {
+      registerOfflineDownload();
+    };
+
+    window.addEventListener('applecottage:gallery-viewed', handleGalleryViewed as EventListener);
+    window.addEventListener('applecottage:tour-watch', handleTourWatch as EventListener);
+    window.addEventListener('applecottage:offline-download', handleOfflineDownload);
+
+    return () => {
+      window.removeEventListener('applecottage:gallery-viewed', handleGalleryViewed as EventListener);
+      window.removeEventListener('applecottage:tour-watch', handleTourWatch as EventListener);
+      window.removeEventListener('applecottage:offline-download', handleOfflineDownload);
+    };
+  }, [registerGalleryView, registerTourWatch, registerOfflineDownload]);
+
+  if (!isSupported || !canInstall || !isPromptVisible) {
+    return null;
+  }
+
+  return (
+    <div className="fixed bottom-4 right-4 z-[2147483646] flex flex-col items-end gap-3" aria-live="polite">
+      <div
+        role="dialog"
+        aria-modal="false"
+        aria-labelledby="a2hs-title"
+        className="max-w-sm rounded-2xl bg-white shadow-2xl border border-slate-200 p-4 sm:p-5 text-slate-900 focus-within:ring-2 focus-within:ring-blue-500"
+      >
+        <div className="flex items-start gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 text-white" aria-hidden="true">
+            📱
+          </div>
+          <div className="flex-1">
+            <h2 id="a2hs-title" className="text-lg font-semibold mb-1">
+              Install Apple Cottage
+            </h2>
+            <p className="text-sm text-slate-600 leading-relaxed">
+              {message}
+            </p>
+          </div>
+        </div>
+        <div className="mt-4 flex flex-wrap gap-2 justify-end">
+          <button
+            type="button"
+            className="rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
+            onClick={dismissPrompt}
+          >
+            Maybe later
+          </button>
+          <button
+            ref={installButtonRef}
+            type="button"
+            className="rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
+            onClick={() => {
+              void showPrompt();
+            }}
+          >
+            Install now
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/a2hs/useA2HS.ts
+++ b/src/components/a2hs/useA2HS.ts
@@ -1,0 +1,167 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+const GALLERY_VIEW_THRESHOLD = 5;
+const TOUR_SECONDS_THRESHOLD = 60;
+
+type TriggerReason = 'gallery' | 'tour' | 'offline';
+
+interface BeforeInstallPromptEvent extends Event {
+  readonly platforms?: string[];
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+}
+
+const isBrowser = typeof window !== 'undefined';
+
+const storageKey = 'applecottage-a2hs-dismissed';
+
+const readDismissedPreference = (): boolean => {
+  if (!isBrowser) return false;
+  try {
+    return window.localStorage?.getItem(storageKey) === '1';
+  } catch {
+    return false;
+  }
+};
+
+const persistDismissedPreference = (value: boolean): void => {
+  if (!isBrowser) return;
+  try {
+    if (value) {
+      window.localStorage?.setItem(storageKey, '1');
+    } else {
+      window.localStorage?.removeItem(storageKey);
+    }
+  } catch {
+    // Ignore persistence failures (Safari private mode, etc.)
+  }
+};
+
+export const useA2HS = () => {
+  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [isPromptVisible, setPromptVisible] = useState(false);
+  const [triggerReason, setTriggerReason] = useState<TriggerReason | null>(null);
+  const [dismissed, setDismissed] = useState<boolean>(() => readDismissedPreference());
+  const [isSupported, setIsSupported] = useState<boolean>(() => isBrowser);
+  const galleryViewsRef = useRef<Set<string>>(new Set());
+  const tourSecondsRef = useRef<number>(0);
+  const offlineTriggeredRef = useRef<boolean>(false);
+
+  const getTriggerReason = useCallback((): TriggerReason | null => {
+    if (!deferredPrompt || dismissed) {
+      return null;
+    }
+    if (offlineTriggeredRef.current) {
+      return 'offline';
+    }
+    if (galleryViewsRef.current.size >= GALLERY_VIEW_THRESHOLD) {
+      return 'gallery';
+    }
+    if (tourSecondsRef.current >= TOUR_SECONDS_THRESHOLD) {
+      return 'tour';
+    }
+    return null;
+  }, [deferredPrompt, dismissed]);
+
+  const evaluatePromptVisibility = useCallback(() => {
+    const reason = getTriggerReason();
+    if (reason) {
+      setTriggerReason(reason);
+      setPromptVisible(true);
+    }
+  }, [getTriggerReason]);
+
+  useEffect(() => {
+    if (!isBrowser) {
+      setIsSupported(false);
+      return;
+    }
+
+    const onBeforeInstallPrompt = (event: Event) => {
+      event.preventDefault();
+      setDeferredPrompt(event as BeforeInstallPromptEvent);
+    };
+
+    const onAppInstalled = () => {
+      setDeferredPrompt(null);
+      setPromptVisible(false);
+      setTriggerReason(null);
+      setDismissed(true);
+      persistDismissedPreference(true);
+    };
+
+    window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt as EventListener, { passive: true });
+    window.addEventListener('appinstalled', onAppInstalled, { passive: true });
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt as EventListener);
+      window.removeEventListener('appinstalled', onAppInstalled);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (deferredPrompt) {
+      evaluatePromptVisibility();
+    }
+  }, [deferredPrompt, evaluatePromptVisibility]);
+
+  const registerGalleryView = useCallback((id: string) => {
+    if (!id) return;
+    galleryViewsRef.current.add(id);
+    evaluatePromptVisibility();
+  }, [evaluatePromptVisibility]);
+
+  const registerTourWatch = useCallback((seconds: number) => {
+    if (!Number.isFinite(seconds) || seconds <= 0) return;
+    tourSecondsRef.current += seconds;
+    evaluatePromptVisibility();
+  }, [evaluatePromptVisibility]);
+
+  const registerOfflineDownload = useCallback(() => {
+    offlineTriggeredRef.current = true;
+    evaluatePromptVisibility();
+  }, [evaluatePromptVisibility]);
+
+  const showPrompt = useCallback(async () => {
+    const promptEvent = deferredPrompt;
+    if (!promptEvent) {
+      return;
+    }
+
+    try {
+      await promptEvent.prompt();
+      await promptEvent.userChoice.catch(() => undefined);
+    } finally {
+      setDeferredPrompt(null);
+      setPromptVisible(false);
+      setTriggerReason(null);
+      setDismissed(true);
+      persistDismissedPreference(true);
+    }
+  }, [deferredPrompt]);
+
+  const dismissPrompt = useCallback(() => {
+    setPromptVisible(false);
+    setTriggerReason(null);
+    setDismissed(true);
+    persistDismissedPreference(true);
+  }, []);
+
+  const canInstall = useMemo(() => Boolean(deferredPrompt) && !dismissed, [deferredPrompt, dismissed]);
+
+  return {
+    isSupported,
+    canInstall,
+    isPromptVisible: isPromptVisible && canInstall,
+    triggerReason,
+    showPrompt,
+    dismissPrompt,
+    registerGalleryView,
+    registerTourWatch,
+    registerOfflineDownload,
+  };
+};
+
+export type UseA2HSResult = ReturnType<typeof useA2HS>;
+
+export default useA2HS;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,6 +6,7 @@ import Footer from '../components/Footer.astro';
 import TrustBar from '../components/TrustBar.astro';
 import StickyCTA from '../components/StickyCTA.astro';
 import site from '../../site.config.ts';
+import InstallPromptIsland from '../components/a2hs/InstallPromptIsland';
 
 const { title = site.title, description = site.description } = Astro.props;
 const gaId = site.analyticsId;
@@ -139,6 +140,7 @@ const gaId = site.analyticsId;
     <Footer />
     <!-- Sticky CTA persists on screen for quick booking / report download -->
     <StickyCTA />
+    <InstallPromptIsland client:load />
     <script type="module">
       import '../pwa.ts';
     </script>

--- a/src/types/pwa.d.ts
+++ b/src/types/pwa.d.ts
@@ -1,11 +1,12 @@
+/* eslint-disable no-unused-vars */
 declare module 'virtual:pwa-register' {
   export interface RegisterSWOptions {
     immediate?: boolean;
     onNeedRefresh?: () => void;
     onOfflineReady?: () => void;
-    onRegistered?: (registration: ServiceWorkerRegistration | undefined) => void;
-    onRegisterError?: (error: any) => void;
+    onRegistered?: (_registration: ServiceWorkerRegistration | undefined) => void;
+    onRegisterError?: (_error: any) => void;
   }
 
-  export function registerSW(options?: RegisterSWOptions): (reloadPage?: boolean) => Promise<void>;
+  export function registerSW(_options?: RegisterSWOptions): (_reloadPage?: boolean) => Promise<void>;
 }


### PR DESCRIPTION
## Summary
- add a dedicated Add-to-Home-Screen hook and island that listens to gallery, tour, and offline-download custom events before showing the install prompt
- emit `applecottage:gallery-viewed` events from the gallery lightbox and `applecottage:tour-watch` pulses from panorama, simple 360, and virtual tour players so engagement counts toward the install threshold
- load the install prompt island from the base layout and tidy up the virtual:pwa-register type declarations used by the build

## Testing
- npm run lint
- npm run test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68cd30455eb08324a118ae0018f93881