### PR TITLE
feat(pwa): add guided update flow and offline signals

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,28 @@ import netlify from '@astrojs/netlify';
 import tailwind from '@astrojs/tailwind';
 import react from '@astrojs/react';
 import VitePWA from '@vite-pwa/astro';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const publicDir = path.resolve(currentDir, 'public');
+
+/** @type {Array<{ url: string, revision: string }>} */
+const offlineEntries = [];
+for (const filename of ['offline.html', 'offline.css']) {
+  const filePath = path.resolve(publicDir, filename);
+  try {
+    const source = fs.readFileSync(filePath);
+    const revision = createHash('sha256').update(source).digest('hex');
+    offlineEntries.push({ url: `/${filename}`, revision });
+  } catch {
+    // File missing in development should not break the build; skip gracefully.
+  }
+}
+
+const offlineFallback = offlineEntries.some((entry) => entry.url === '/offline.html') ? '/offline.html' : undefined;
 
 export default defineConfig({
   site: 'https://applecottagecreetown.co.uk',
@@ -17,8 +39,10 @@ export default defineConfig({
       injectRegister: null, // we manually register the SW from a client-only module.
       manifest: false, // reuse the existing public/site.webmanifest that is already curated.
       workbox: {
+        additionalManifestEntries: offlineEntries,
         clientsClaim: true,
         skipWaiting: true,
+        ...(offlineFallback ? { navigateFallback: offlineFallback } : {}),
         navigateFallbackDenylist: [/^\/api\//],
         // Exclude HTML from the precache manifest to avoid shipping stale markup.
         globPatterns: ['**/*.{js,css,ico,png,svg,webp,avif,jpg,jpeg,json,woff2,woff}'],

--- a/docs/pwa-verification-checklist.md
+++ b/docs/pwa-verification-checklist.md
@@ -23,4 +23,5 @@ Use this quick runbook each time you deploy to make sure the new service worker 
 - **No HTML in precache**: Navigations use a network-first strategy which prevents stale markup from sticking around after deploys.
 - **Runtime caching**: Assets (CSS/JS/images/fonts) use `StaleWhileRevalidate` for instant loads with background refreshes; `/api/*` GETs get a tiny 60s cache for resiliency; mutations never touch the cache.
 - **Prompt helper**: `registerServiceWorkerWithPrompt` exposes a toast-based UX that calls `updateSW(true)` so teams can choose between silent updates and user-driven refreshes.
+- **Install analytics**: `useA2HS` emits `a2hs_*` events to `gtag`/`dataLayer` so marketing can monitor when the prompt appears, is dismissed, or completes. Filter by `event_category: 'pwa'` to analyse install funnels by trigger reason.
 - **Dev ergonomics**: `devOptions.enabled` keeps the worker available locally, but the note in config documents that it should be disabled if it confuses local QA.

--- a/docs/pwa-verification-checklist.md
+++ b/docs/pwa-verification-checklist.md
@@ -10,6 +10,7 @@ Use this quick runbook each time you deploy to make sure the new service worker 
 3. In the preview, load the page, then refresh. Updated copy should appear without a hard reload.
 4. In DevTools, switch the network tab to **Offline** and reload.
    - Critical UI (shell, cached assets) should load from cache, API requests can fail gracefully.
+   - Navigations should fall back to `/offline.html` with the action links usable while disconnected.
 5. Visit `/api/*` endpoints and ensure only GET calls are cached. Confirm POST/PUT/PATCH/DELETE bypass the service worker.
 6. Re-test after invalidating caches in DevTools (**Clear site data**) to simulate a first-time visitor.
 7. During development, disable the worker with `navigator.serviceWorker.getRegistrations().then(list => list.forEach(r => r.unregister()))` if it interferes, then reload.

--- a/docs/pwa-verification-checklist.md
+++ b/docs/pwa-verification-checklist.md
@@ -24,4 +24,5 @@ Use this quick runbook each time you deploy to make sure the new service worker 
 - **Runtime caching**: Assets (CSS/JS/images/fonts) use `StaleWhileRevalidate` for instant loads with background refreshes; `/api/*` GETs get a tiny 60s cache for resiliency; mutations never touch the cache.
 - **Prompt helper**: `registerServiceWorkerWithPrompt` exposes a toast-based UX that calls `updateSW(true)` so teams can choose between silent updates and user-driven refreshes.
 - **Install analytics**: `useA2HS` emits `a2hs_*` events to `gtag`/`dataLayer` so marketing can monitor when the prompt appears, is dismissed, or completes. Filter by `event_category: 'pwa'` to analyse install funnels by trigger reason.
+- **Manual install fallback**: Safari users see Add to Home Screen instructions once the engagement threshold is met. Track these as `a2hs_manual_*` events to confirm iOS visitors receive guidance.
 - **Dev ergonomics**: `devOptions.enabled` keeps the worker available locally, but the note in config documents that it should be disabled if it confuses local QA.

--- a/src/components/a2hs/InstallPromptIsland.tsx
+++ b/src/components/a2hs/InstallPromptIsland.tsx
@@ -7,6 +7,9 @@ export default function InstallPromptIsland(): JSX.Element | null {
     canInstall,
     isPromptVisible,
     triggerReason,
+    promptVariant,
+    manualPlatform,
+    manualInstructions,
     showPrompt,
     dismissPrompt,
     registerGalleryView,
@@ -15,6 +18,7 @@ export default function InstallPromptIsland(): JSX.Element | null {
   } = useA2HS();
 
   const installButtonRef = useRef<HTMLButtonElement>(null);
+  const dismissButtonRef = useRef<HTMLButtonElement>(null);
 
   const message = useMemo(() => {
     switch (triggerReason) {
@@ -29,13 +33,29 @@ export default function InstallPromptIsland(): JSX.Element | null {
     }
   }, [triggerReason]);
 
+  const isManualPrompt = promptVariant === 'manual';
+  const title = isManualPrompt ? 'Add Apple Cottage to your home screen' : 'Install Apple Cottage';
+  const manualDescription = useMemo(() => {
+    if (!isManualPrompt) {
+      return null;
+    }
+    if (manualPlatform === 'ios') {
+      return 'Follow these quick steps in Safari to keep Apple Cottage just a tap away.';
+    }
+    return 'Follow these quick steps to save Apple Cottage to your device.';
+  }, [isManualPrompt, manualPlatform]);
+
   useEffect(() => {
     if (!isPromptVisible) return;
     const id = window.setTimeout(() => {
-      installButtonRef.current?.focus();
+      if (isManualPrompt) {
+        dismissButtonRef.current?.focus();
+      } else {
+        installButtonRef.current?.focus();
+      }
     }, 0);
     return () => window.clearTimeout(id);
-  }, [isPromptVisible]);
+  }, [isManualPrompt, isPromptVisible]);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -73,7 +93,11 @@ export default function InstallPromptIsland(): JSX.Element | null {
     };
   }, [registerGalleryView, registerTourWatch, registerOfflineDownload]);
 
-  if (!isSupported || !canInstall || !isPromptVisible) {
+  if (!isSupported || !isPromptVisible) {
+    return null;
+  }
+
+  if (!isManualPrompt && !canInstall) {
     return null;
   }
 
@@ -91,31 +115,47 @@ export default function InstallPromptIsland(): JSX.Element | null {
           </div>
           <div className="flex-1">
             <h2 id="a2hs-title" className="text-lg font-semibold mb-1">
-              Install Apple Cottage
+              {title}
             </h2>
-            <p className="text-sm text-slate-600 leading-relaxed">
-              {message}
-            </p>
+            {isManualPrompt ? (
+              <div className="space-y-3 text-sm text-slate-600 leading-relaxed">
+                <p>{manualDescription}</p>
+                {manualInstructions.length > 0 && (
+                  <ol className="list-decimal list-inside space-y-1" aria-label="Steps to add Apple Cottage to your home screen">
+                    {manualInstructions.map((instruction, index) => (
+                      <li key={`${index}-${instruction}`}>{instruction}</li>
+                    ))}
+                  </ol>
+                )}
+              </div>
+            ) : (
+              <p className="text-sm text-slate-600 leading-relaxed">
+                {message}
+              </p>
+            )}
           </div>
         </div>
         <div className="mt-4 flex flex-wrap gap-2 justify-end">
           <button
             type="button"
+            ref={isManualPrompt ? dismissButtonRef : undefined}
             className="rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
             onClick={dismissPrompt}
           >
-            Maybe later
+            {isManualPrompt ? 'Got it' : 'Maybe later'}
           </button>
-          <button
-            ref={installButtonRef}
-            type="button"
-            className="rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
-            onClick={() => {
-              void showPrompt();
-            }}
-          >
-            Install now
-          </button>
+          {!isManualPrompt && (
+            <button
+              ref={installButtonRef}
+              type="button"
+              className="rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
+              onClick={() => {
+                void showPrompt();
+              }}
+            >
+              Install now
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/a2hs/useA2HS.ts
+++ b/src/components/a2hs/useA2HS.ts
@@ -15,6 +15,71 @@ const isBrowser = typeof window !== 'undefined';
 
 const storageKey = 'applecottage-a2hs-dismissed';
 
+type AnalyticsPayload = Record<string, unknown>;
+
+const cleanPayload = (payload: AnalyticsPayload = {}): AnalyticsPayload => {
+  return Object.fromEntries(
+    Object.entries(payload).filter(([, value]) => value !== undefined && value !== null && value !== ''),
+  );
+};
+
+type AnalyticsWindow = Window & {
+  gtag?: unknown;
+  dataLayer?: unknown;
+};
+
+const getAnalyticsWindow = (): AnalyticsWindow | undefined => {
+  if (!isBrowser) {
+    return undefined;
+  }
+
+  return window as AnalyticsWindow;
+};
+
+const trackPwaEvent = (eventName: string, payload: AnalyticsPayload = {}): void => {
+  const analyticsWindow = getAnalyticsWindow();
+  if (!analyticsWindow) {
+    return;
+  }
+
+  const basePayload = cleanPayload({
+    event_category: 'pwa',
+    engagement_gallery_views: payload.engagement_gallery_views,
+    engagement_tour_seconds: payload.engagement_tour_seconds,
+    engagement_offline_ready: payload.engagement_offline_ready,
+    trigger_reason: payload.trigger_reason,
+    outcome: payload.outcome,
+    platform: payload.platform,
+  });
+
+  if (typeof analyticsWindow.gtag === 'function') {
+    try {
+      const gtagFunction = analyticsWindow.gtag as CallableFunction;
+      gtagFunction.call(analyticsWindow, 'event', eventName, basePayload);
+    } catch {
+      // Ignore gtag errors — analytics should never block UX.
+    }
+  }
+
+  const dataLayer = Array.isArray(analyticsWindow.dataLayer)
+    ? (analyticsWindow.dataLayer as AnalyticsPayload[])
+    : undefined;
+
+  try {
+    const dataLayerEvent: AnalyticsPayload = cleanPayload({
+      event: eventName,
+      ...basePayload,
+    });
+    if (dataLayer) {
+      dataLayer.push(dataLayerEvent);
+    } else {
+      (analyticsWindow as AnalyticsWindow & { dataLayer: AnalyticsPayload[] }).dataLayer = [dataLayerEvent];
+    }
+  } catch {
+    // Ignore analytics failures (e.g. blocked storage).
+  }
+};
+
 const readDismissedPreference = (): boolean => {
   if (!isBrowser) return false;
   try {
@@ -46,6 +111,12 @@ export const useA2HS = () => {
   const galleryViewsRef = useRef<Set<string>>(new Set());
   const tourSecondsRef = useRef<number>(0);
   const offlineTriggeredRef = useRef<boolean>(false);
+  const galleryThresholdLoggedRef = useRef<boolean>(false);
+  const tourThresholdLoggedRef = useRef<boolean>(false);
+  const offlineLoggedRef = useRef<boolean>(false);
+  const promptVisibleRef = useRef<boolean>(false);
+  const lastReportedReasonRef = useRef<TriggerReason | null>(null);
+  const triggerReasonRef = useRef<TriggerReason | null>(null);
 
   const getTriggerReason = useCallback((): TriggerReason | null => {
     if (!deferredPrompt || dismissed) {
@@ -68,6 +139,16 @@ export const useA2HS = () => {
     if (reason) {
       setTriggerReason(reason);
       setPromptVisible(true);
+      const engagementSnapshot = {
+        engagement_gallery_views: galleryViewsRef.current.size,
+        engagement_tour_seconds: tourSecondsRef.current,
+        engagement_offline_ready: offlineTriggeredRef.current,
+        trigger_reason: reason,
+      };
+      if (!promptVisibleRef.current || lastReportedReasonRef.current !== reason) {
+        trackPwaEvent('a2hs_prompt_ready', engagementSnapshot);
+        lastReportedReasonRef.current = reason;
+      }
     }
   }, [getTriggerReason]);
 
@@ -80,6 +161,7 @@ export const useA2HS = () => {
     const onBeforeInstallPrompt = (event: Event) => {
       event.preventDefault();
       setDeferredPrompt(event as BeforeInstallPromptEvent);
+      trackPwaEvent('a2hs_event_captured');
     };
 
     const onAppInstalled = () => {
@@ -88,6 +170,7 @@ export const useA2HS = () => {
       setTriggerReason(null);
       setDismissed(true);
       persistDismissedPreference(true);
+      trackPwaEvent('a2hs_installed');
     };
 
     window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt as EventListener, { passive: true });
@@ -105,21 +188,61 @@ export const useA2HS = () => {
     }
   }, [deferredPrompt, evaluatePromptVisibility]);
 
+  useEffect(() => {
+    promptVisibleRef.current = isPromptVisible;
+    triggerReasonRef.current = triggerReason;
+    if (isPromptVisible && triggerReason) {
+      trackPwaEvent('a2hs_prompt_shown', {
+        trigger_reason: triggerReason,
+        engagement_gallery_views: galleryViewsRef.current.size,
+        engagement_tour_seconds: tourSecondsRef.current,
+        engagement_offline_ready: offlineTriggeredRef.current,
+      });
+    }
+  }, [isPromptVisible, triggerReason]);
+
   const registerGalleryView = useCallback((id: string) => {
     if (!id) return;
     galleryViewsRef.current.add(id);
     evaluatePromptVisibility();
+    if (!galleryThresholdLoggedRef.current && galleryViewsRef.current.size >= GALLERY_VIEW_THRESHOLD) {
+      galleryThresholdLoggedRef.current = true;
+      trackPwaEvent('a2hs_gallery_threshold_met', {
+        trigger_reason: triggerReasonRef.current,
+        engagement_gallery_views: galleryViewsRef.current.size,
+        engagement_tour_seconds: tourSecondsRef.current,
+        engagement_offline_ready: offlineTriggeredRef.current,
+      });
+    }
   }, [evaluatePromptVisibility]);
 
   const registerTourWatch = useCallback((seconds: number) => {
     if (!Number.isFinite(seconds) || seconds <= 0) return;
     tourSecondsRef.current += seconds;
     evaluatePromptVisibility();
+    if (!tourThresholdLoggedRef.current && tourSecondsRef.current >= TOUR_SECONDS_THRESHOLD) {
+      tourThresholdLoggedRef.current = true;
+      trackPwaEvent('a2hs_tour_threshold_met', {
+        trigger_reason: triggerReasonRef.current,
+        engagement_gallery_views: galleryViewsRef.current.size,
+        engagement_tour_seconds: tourSecondsRef.current,
+        engagement_offline_ready: offlineTriggeredRef.current,
+      });
+    }
   }, [evaluatePromptVisibility]);
 
   const registerOfflineDownload = useCallback(() => {
     offlineTriggeredRef.current = true;
     evaluatePromptVisibility();
+    if (!offlineLoggedRef.current) {
+      offlineLoggedRef.current = true;
+      trackPwaEvent('a2hs_offline_ready', {
+        trigger_reason: triggerReasonRef.current,
+        engagement_gallery_views: galleryViewsRef.current.size,
+        engagement_tour_seconds: tourSecondsRef.current,
+        engagement_offline_ready: offlineTriggeredRef.current,
+      });
+    }
   }, [evaluatePromptVisibility]);
 
   const showPrompt = useCallback(async () => {
@@ -128,9 +251,35 @@ export const useA2HS = () => {
       return;
     }
 
+    trackPwaEvent('a2hs_prompt_launch', {
+      trigger_reason: triggerReasonRef.current,
+      engagement_gallery_views: galleryViewsRef.current.size,
+      engagement_tour_seconds: tourSecondsRef.current,
+      engagement_offline_ready: offlineTriggeredRef.current,
+    });
+
     try {
       await promptEvent.prompt();
-      await promptEvent.userChoice.catch(() => undefined);
+      const choice = await promptEvent.userChoice.catch(() => undefined);
+      if (choice) {
+        trackPwaEvent('a2hs_prompt_resolved', {
+          trigger_reason: triggerReasonRef.current,
+          engagement_gallery_views: galleryViewsRef.current.size,
+          engagement_tour_seconds: tourSecondsRef.current,
+          engagement_offline_ready: offlineTriggeredRef.current,
+          outcome: choice.outcome,
+          platform: choice.platform,
+        });
+        if (choice.outcome === 'accepted') {
+          trackPwaEvent('a2hs_prompt_accepted', {
+            trigger_reason: triggerReasonRef.current,
+            engagement_gallery_views: galleryViewsRef.current.size,
+            engagement_tour_seconds: tourSecondsRef.current,
+            engagement_offline_ready: offlineTriggeredRef.current,
+            platform: choice.platform,
+          });
+        }
+      }
     } finally {
       setDeferredPrompt(null);
       setPromptVisible(false);
@@ -145,6 +294,12 @@ export const useA2HS = () => {
     setTriggerReason(null);
     setDismissed(true);
     persistDismissedPreference(true);
+    trackPwaEvent('a2hs_prompt_dismissed', {
+      trigger_reason: triggerReasonRef.current,
+      engagement_gallery_views: galleryViewsRef.current.size,
+      engagement_tour_seconds: tourSecondsRef.current,
+      engagement_offline_ready: offlineTriggeredRef.current,
+    });
   }, []);
 
   const canInstall = useMemo(() => Boolean(deferredPrompt) && !dismissed, [deferredPrompt, dismissed]);

--- a/src/components/a2hs/useA2HS.ts
+++ b/src/components/a2hs/useA2HS.ts
@@ -4,6 +4,8 @@ const GALLERY_VIEW_THRESHOLD = 5;
 const TOUR_SECONDS_THRESHOLD = 60;
 
 type TriggerReason = 'gallery' | 'tour' | 'offline';
+type PromptVariant = 'native' | 'manual';
+type ManualPlatform = 'ios';
 
 interface BeforeInstallPromptEvent extends Event {
   readonly platforms?: string[];
@@ -50,6 +52,8 @@ const trackPwaEvent = (eventName: string, payload: AnalyticsPayload = {}): void 
     trigger_reason: payload.trigger_reason,
     outcome: payload.outcome,
     platform: payload.platform,
+    prompt_variant: payload.prompt_variant,
+    manual_platform: payload.manual_platform,
   });
 
   if (typeof analyticsWindow.gtag === 'function') {
@@ -106,8 +110,33 @@ export const useA2HS = () => {
   const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
   const [isPromptVisible, setPromptVisible] = useState(false);
   const [triggerReason, setTriggerReason] = useState<TriggerReason | null>(null);
+  const [promptVariant, setPromptVariant] = useState<PromptVariant | null>(null);
   const [dismissed, setDismissed] = useState<boolean>(() => readDismissedPreference());
-  const [isSupported, setIsSupported] = useState<boolean>(() => isBrowser);
+  const [supportsInstallPrompt, setSupportsInstallPrompt] = useState<boolean>(() => {
+    if (!isBrowser) {
+      return false;
+    }
+    return 'onbeforeinstallprompt' in window || 'BeforeInstallPromptEvent' in window;
+  });
+  const [isStandalone, setIsStandalone] = useState<boolean>(() => {
+    if (!isBrowser) {
+      return false;
+    }
+    if (window.matchMedia?.('(display-mode: standalone)').matches) {
+      return true;
+    }
+    return Boolean((window.navigator as Navigator & { standalone?: boolean }).standalone);
+  });
+  const [isSupported, setIsSupported] = useState<boolean>(() => {
+    if (!isBrowser) {
+      return false;
+    }
+    return (
+      'onbeforeinstallprompt' in window ||
+      'BeforeInstallPromptEvent' in window ||
+      /iphone|ipad|ipod/i.test(window.navigator.userAgent || '')
+    );
+  });
   const galleryViewsRef = useRef<Set<string>>(new Set());
   const tourSecondsRef = useRef<number>(0);
   const offlineTriggeredRef = useRef<boolean>(false);
@@ -117,11 +146,46 @@ export const useA2HS = () => {
   const promptVisibleRef = useRef<boolean>(false);
   const lastReportedReasonRef = useRef<TriggerReason | null>(null);
   const triggerReasonRef = useRef<TriggerReason | null>(null);
+  const promptVariantRef = useRef<PromptVariant | null>(null);
 
-  const getTriggerReason = useCallback((): TriggerReason | null => {
-    if (!deferredPrompt || dismissed) {
+  const isIosDevice = useMemo(() => {
+    if (!isBrowser) {
+      return false;
+    }
+    const userAgent = window.navigator.userAgent || '';
+    return /iphone|ipad|ipod/i.test(userAgent);
+  }, []);
+
+  const manualPlatform = useMemo<ManualPlatform | null>(() => {
+    if (!isBrowser) {
       return null;
     }
+    if (dismissed) {
+      return null;
+    }
+    if (supportsInstallPrompt) {
+      return null;
+    }
+    if (!isIosDevice) {
+      return null;
+    }
+    if (isStandalone) {
+      return null;
+    }
+    return 'ios';
+  }, [dismissed, isIosDevice, isStandalone, supportsInstallPrompt]);
+
+  const getTriggerReason = useCallback((): TriggerReason | null => {
+    if (dismissed) {
+      return null;
+    }
+
+    const hasDeferredPrompt = Boolean(deferredPrompt);
+    const canShowManual = manualPlatform !== null;
+    if (!hasDeferredPrompt && !canShowManual) {
+      return null;
+    }
+
     if (offlineTriggeredRef.current) {
       return 'offline';
     }
@@ -132,25 +196,38 @@ export const useA2HS = () => {
       return 'tour';
     }
     return null;
-  }, [deferredPrompt, dismissed]);
+  }, [deferredPrompt, dismissed, manualPlatform]);
 
   const evaluatePromptVisibility = useCallback(() => {
     const reason = getTriggerReason();
     if (reason) {
       setTriggerReason(reason);
+      const hasDeferredPrompt = Boolean(deferredPrompt);
+      const variant: PromptVariant | null = hasDeferredPrompt ? 'native' : manualPlatform ? 'manual' : null;
+      if (!variant) {
+        return;
+      }
+      setPromptVariant(variant);
       setPromptVisible(true);
       const engagementSnapshot = {
         engagement_gallery_views: galleryViewsRef.current.size,
         engagement_tour_seconds: tourSecondsRef.current,
         engagement_offline_ready: offlineTriggeredRef.current,
         trigger_reason: reason,
+        prompt_variant: variant,
+        manual_platform: manualPlatform,
       };
-      if (!promptVisibleRef.current || lastReportedReasonRef.current !== reason) {
-        trackPwaEvent('a2hs_prompt_ready', engagementSnapshot);
+      if (
+        !promptVisibleRef.current ||
+        lastReportedReasonRef.current !== reason ||
+        promptVariantRef.current !== variant
+      ) {
+        trackPwaEvent(variant === 'native' ? 'a2hs_prompt_ready' : 'a2hs_manual_ready', engagementSnapshot);
         lastReportedReasonRef.current = reason;
+        promptVariantRef.current = variant;
       }
     }
-  }, [getTriggerReason]);
+  }, [deferredPrompt, getTriggerReason, manualPlatform]);
 
   useEffect(() => {
     if (!isBrowser) {
@@ -161,6 +238,8 @@ export const useA2HS = () => {
     const onBeforeInstallPrompt = (event: Event) => {
       event.preventDefault();
       setDeferredPrompt(event as BeforeInstallPromptEvent);
+      setSupportsInstallPrompt(true);
+      setIsSupported(true);
       trackPwaEvent('a2hs_event_captured');
     };
 
@@ -168,8 +247,10 @@ export const useA2HS = () => {
       setDeferredPrompt(null);
       setPromptVisible(false);
       setTriggerReason(null);
+      setPromptVariant(null);
       setDismissed(true);
       persistDismissedPreference(true);
+      setIsStandalone(true);
       trackPwaEvent('a2hs_installed');
     };
 
@@ -186,20 +267,54 @@ export const useA2HS = () => {
     if (deferredPrompt) {
       evaluatePromptVisibility();
     }
-  }, [deferredPrompt, evaluatePromptVisibility]);
+  }, [deferredPrompt, evaluatePromptVisibility, manualPlatform]);
+
+  useEffect(() => {
+    if (!isBrowser) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia?.('(display-mode: standalone)');
+    const updateStandalone = () => {
+      const matchesMedia = Boolean(mediaQuery?.matches);
+      const navigatorStandalone = Boolean((window.navigator as Navigator & { standalone?: boolean }).standalone);
+      setIsStandalone(matchesMedia || navigatorStandalone);
+    };
+
+    updateStandalone();
+
+    mediaQuery?.addEventListener?.('change', updateStandalone);
+    const onVisibility = () => updateStandalone();
+    window.addEventListener('visibilitychange', onVisibility);
+
+    return () => {
+      mediaQuery?.removeEventListener?.('change', updateStandalone);
+      window.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isBrowser) {
+      return;
+    }
+    setIsSupported(supportsInstallPrompt || manualPlatform !== null);
+  }, [manualPlatform, supportsInstallPrompt]);
 
   useEffect(() => {
     promptVisibleRef.current = isPromptVisible;
     triggerReasonRef.current = triggerReason;
-    if (isPromptVisible && triggerReason) {
-      trackPwaEvent('a2hs_prompt_shown', {
+    promptVariantRef.current = promptVariant;
+    if (isPromptVisible && triggerReason && promptVariant) {
+      trackPwaEvent(promptVariant === 'native' ? 'a2hs_prompt_shown' : 'a2hs_manual_shown', {
         trigger_reason: triggerReason,
         engagement_gallery_views: galleryViewsRef.current.size,
         engagement_tour_seconds: tourSecondsRef.current,
         engagement_offline_ready: offlineTriggeredRef.current,
+        prompt_variant: promptVariant,
+        manual_platform: manualPlatform,
       });
     }
-  }, [isPromptVisible, triggerReason]);
+  }, [isPromptVisible, manualPlatform, promptVariant, triggerReason]);
 
   const registerGalleryView = useCallback((id: string) => {
     if (!id) return;
@@ -212,9 +327,11 @@ export const useA2HS = () => {
         engagement_gallery_views: galleryViewsRef.current.size,
         engagement_tour_seconds: tourSecondsRef.current,
         engagement_offline_ready: offlineTriggeredRef.current,
+        prompt_variant: promptVariantRef.current,
+        manual_platform: manualPlatform,
       });
     }
-  }, [evaluatePromptVisibility]);
+  }, [evaluatePromptVisibility, manualPlatform]);
 
   const registerTourWatch = useCallback((seconds: number) => {
     if (!Number.isFinite(seconds) || seconds <= 0) return;
@@ -227,9 +344,11 @@ export const useA2HS = () => {
         engagement_gallery_views: galleryViewsRef.current.size,
         engagement_tour_seconds: tourSecondsRef.current,
         engagement_offline_ready: offlineTriggeredRef.current,
+        prompt_variant: promptVariantRef.current,
+        manual_platform: manualPlatform,
       });
     }
-  }, [evaluatePromptVisibility]);
+  }, [evaluatePromptVisibility, manualPlatform]);
 
   const registerOfflineDownload = useCallback(() => {
     offlineTriggeredRef.current = true;
@@ -241,11 +360,29 @@ export const useA2HS = () => {
         engagement_gallery_views: galleryViewsRef.current.size,
         engagement_tour_seconds: tourSecondsRef.current,
         engagement_offline_ready: offlineTriggeredRef.current,
+        prompt_variant: promptVariantRef.current,
+        manual_platform: manualPlatform,
       });
     }
-  }, [evaluatePromptVisibility]);
+  }, [evaluatePromptVisibility, manualPlatform]);
 
   const showPrompt = useCallback(async () => {
+    if (promptVariantRef.current === 'manual') {
+      trackPwaEvent('a2hs_manual_acknowledged', {
+        trigger_reason: triggerReasonRef.current,
+        engagement_gallery_views: galleryViewsRef.current.size,
+        engagement_tour_seconds: tourSecondsRef.current,
+        engagement_offline_ready: offlineTriggeredRef.current,
+        prompt_variant: promptVariantRef.current,
+        manual_platform: manualPlatform,
+      });
+      setPromptVisible(false);
+      setTriggerReason(null);
+      setPromptVariant(null);
+      setDismissed(true);
+      persistDismissedPreference(true);
+      return;
+    }
     const promptEvent = deferredPrompt;
     if (!promptEvent) {
       return;
@@ -284,31 +421,48 @@ export const useA2HS = () => {
       setDeferredPrompt(null);
       setPromptVisible(false);
       setTriggerReason(null);
+      setPromptVariant(null);
       setDismissed(true);
       persistDismissedPreference(true);
     }
-  }, [deferredPrompt]);
+  }, [deferredPrompt, manualPlatform]);
 
   const dismissPrompt = useCallback(() => {
     setPromptVisible(false);
     setTriggerReason(null);
+    setPromptVariant(null);
     setDismissed(true);
     persistDismissedPreference(true);
-    trackPwaEvent('a2hs_prompt_dismissed', {
+    trackPwaEvent(promptVariantRef.current === 'manual' ? 'a2hs_manual_dismissed' : 'a2hs_prompt_dismissed', {
       trigger_reason: triggerReasonRef.current,
       engagement_gallery_views: galleryViewsRef.current.size,
       engagement_tour_seconds: tourSecondsRef.current,
       engagement_offline_ready: offlineTriggeredRef.current,
+      prompt_variant: promptVariantRef.current,
+      manual_platform: manualPlatform,
     });
-  }, []);
+  }, [manualPlatform]);
 
   const canInstall = useMemo(() => Boolean(deferredPrompt) && !dismissed, [deferredPrompt, dismissed]);
+  const manualInstructions = useMemo(() => {
+    if (manualPlatform === 'ios') {
+      return [
+        'Tap the share button in Safari\'s toolbar.',
+        'Scroll down and choose “Add to Home Screen”.',
+        'Pick a name if prompted, then tap “Add”.',
+      ];
+    }
+    return [];
+  }, [manualPlatform]);
 
   return {
     isSupported,
     canInstall,
-    isPromptVisible: isPromptVisible && canInstall,
+    isPromptVisible: isPromptVisible && (promptVariant !== null),
     triggerReason,
+    promptVariant,
+    manualPlatform,
+    manualInstructions,
     showPrompt,
     dismissPrompt,
     registerGalleryView,

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -36,6 +36,8 @@ const gaId = site.analyticsId;
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="mask-icon" href="/icons/pwa-icon.svg" color="#1f6c84" />
     <link rel="manifest" href="/site.webmanifest" />
+    <link rel="prefetch" href="/offline.html" as="document" importance="low" />
+    <link rel="prefetch" href="/offline.css" as="style" importance="low" />
     {site.hero?.image && <link rel="preload" as="image" href={site.hero.image} />}
       {gaId && (
         <script is:inline>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -142,7 +142,24 @@ const gaId = site.analyticsId;
     <StickyCTA />
     <InstallPromptIsland client:load />
     <script type="module">
-      import '../pwa.ts';
+      import { registerServiceWorkerWithPrompt } from '../pwa.ts';
+
+      if (typeof window !== 'undefined') {
+        try {
+          registerServiceWorkerWithPrompt({
+            onRegistered(registration) {
+              if (import.meta.env.DEV) {
+                window?.console?.info?.('Service worker registered', registration);
+              }
+            },
+            onRegisterError(error) {
+              window?.console?.error?.('Service worker registration failed', error);
+            }
+          });
+        } catch (error) {
+          window?.console?.error?.('Unable to initialise the service worker', error);
+        }
+      }
     </script>
   </body>
 </html>

--- a/src/pwa.ts
+++ b/src/pwa.ts
@@ -8,14 +8,17 @@ type Cleanup = () => void;
 
 const isBrowser = typeof window !== 'undefined';
 
-if (isBrowser) {
-  // Silent auto-update: the plugin will update assets in the background and reload controlled tabs.
-  registerSW({ immediate: true });
-}
+export const registerServiceWorker = (options?: RegisterSWOptions): UpdateFunction | undefined => {
+  if (!isBrowser) {
+    return undefined;
+  }
+
+  return registerSW({ immediate: true, ...options });
+};
 
 /**
  * Prompt-based flow if you prefer to control when the reload happens.
- * Call this instead of the auto-update above to surface a UI prompt.
+ * Call this instead of the auto-update to surface a UI prompt.
  */
 export const registerServiceWorkerWithPrompt = (options?: RegisterSWOptions): UpdateFunction | undefined => {
   if (!isBrowser) {
@@ -24,13 +27,18 @@ export const registerServiceWorkerWithPrompt = (options?: RegisterSWOptions): Up
 
   const { onNeedRefresh: userNeedRefresh, onOfflineReady: userOfflineReady, ...restOptions } = options ?? {};
 
-  let updateSWRef: UpdateFunction;
+  let updateSWRef: UpdateFunction | undefined;
 
   const updateSW = registerSW({
     ...restOptions,
     immediate: false,
     onNeedRefresh() {
-      renderUpdatePrompt(() => (updateSWRef ? updateSWRef(true) : Promise.resolve()));
+      renderUpdatePrompt(async () => {
+        if (!updateSWRef) {
+          return;
+        }
+        await updateSWRef(true);
+      });
       userNeedRefresh?.();
     },
     onOfflineReady() {
@@ -46,12 +54,16 @@ export const registerServiceWorkerWithPrompt = (options?: RegisterSWOptions): Up
 const renderUpdatePrompt = (onConfirm: () => Promise<void>): Cleanup => {
   ensurePromptStyles();
 
-  const root = document.createElement('div');
-  root.className = 'pwa-update-toast';
-  root.setAttribute('role', 'alert');
-  root.setAttribute('aria-live', 'assertive');
+  document.querySelectorAll('.pwa-update-toast').forEach((existing) => existing.remove());
 
-  const heading = document.createElement('p');
+  const root = document.createElement('aside');
+  root.className = 'pwa-update-toast';
+  root.setAttribute('role', 'dialog');
+  root.setAttribute('aria-modal', 'false');
+  root.setAttribute('aria-live', 'assertive');
+  root.tabIndex = -1;
+
+  const heading = document.createElement('h2');
   heading.textContent = 'Update available';
   heading.className = 'pwa-update-toast__title';
   heading.id = 'pwa-update-toast__title';
@@ -59,6 +71,7 @@ const renderUpdatePrompt = (onConfirm: () => Promise<void>): Cleanup => {
   const description = document.createElement('p');
   description.textContent = 'Reload to get the newest fixes and content.';
   description.className = 'pwa-update-toast__description';
+  description.id = 'pwa-update-toast__description';
 
   const buttonRow = document.createElement('div');
   buttonRow.className = 'pwa-update-toast__actions';
@@ -71,7 +84,7 @@ const renderUpdatePrompt = (onConfirm: () => Promise<void>): Cleanup => {
   reloadButton.type = 'button';
   reloadButton.textContent = 'Reload now';
   reloadButton.className = 'pwa-update-toast__reload';
-  reloadButton.setAttribute('aria-describedby', heading.id);
+  reloadButton.setAttribute('aria-describedby', `${heading.id} ${description.id}`);
   reloadButton.addEventListener('click', () => {
     reloadButton.disabled = true;
     void onConfirm().finally(cleanup);
@@ -87,9 +100,14 @@ const renderUpdatePrompt = (onConfirm: () => Promise<void>): Cleanup => {
 
   buttonRow.append(reloadButton, dismissButton);
   root.append(heading, description, buttonRow);
+  root.setAttribute('aria-labelledby', heading.id);
+  root.setAttribute('aria-describedby', description.id);
 
   document.body.append(root);
-  root.focus?.();
+
+  window.setTimeout(() => {
+    root.focus?.();
+  }, 0);
 
   return cleanup;
 };
@@ -97,12 +115,19 @@ const renderUpdatePrompt = (onConfirm: () => Promise<void>): Cleanup => {
 const announceOfflineReady = (): void => {
   ensurePromptStyles();
 
-  const offlineNotice = document.createElement('div');
+  const offlineNotice = document.createElement('aside');
   offlineNotice.setAttribute('role', 'status');
+  offlineNotice.setAttribute('aria-live', 'polite');
   offlineNotice.textContent = 'The site is ready to work offline.';
   offlineNotice.className = 'pwa-offline-toast';
 
   document.body.append(offlineNotice);
+
+  try {
+    window.dispatchEvent(new CustomEvent('applecottage:offline-download'));
+  } catch {
+    // Dispatch may fail in older browsers without CustomEvent support; ignore gracefully.
+  }
 
   window.setTimeout(() => {
     offlineNotice.remove();
@@ -129,9 +154,14 @@ const ensurePromptStyles = (): void => {
       box-shadow: 0 12px 30px rgba(15, 23, 42, 0.35);
       display: flex;
       flex-direction: column;
-      gap: 0.5rem;
+      gap: 0.75rem;
       max-width: 20rem;
       font-family: var(--font-sans, system-ui, sans-serif);
+    }
+
+    .pwa-update-toast:focus {
+      outline: 3px solid var(--color-focus-ring, #facc15);
+      outline-offset: 4px;
     }
 
     .pwa-update-toast__title {
@@ -149,6 +179,7 @@ const ensurePromptStyles = (): void => {
       display: flex;
       gap: 0.5rem;
       flex-wrap: wrap;
+      justify-content: flex-end;
     }
 
     .pwa-update-toast__reload {
@@ -159,6 +190,12 @@ const ensurePromptStyles = (): void => {
       border: none;
       border-radius: 999px;
       cursor: pointer;
+      transition: transform 0.15s ease, background-color 0.15s ease;
+    }
+
+    .pwa-update-toast__reload:hover {
+      background-color: var(--color-accent-strong, #fb923c);
+      transform: translateY(-1px);
     }
 
     .pwa-update-toast__reload:focus-visible,
@@ -174,6 +211,11 @@ const ensurePromptStyles = (): void => {
       border-radius: 999px;
       padding: 0.5rem 1rem;
       cursor: pointer;
+      transition: color 0.15s ease, background-color 0.15s ease;
+    }
+
+    .pwa-update-toast__dismiss:hover {
+      background-color: rgba(255, 255, 255, 0.12);
     }
 
     .pwa-offline-toast {
@@ -182,7 +224,7 @@ const ensurePromptStyles = (): void => {
       inset-block-start: 1rem;
       background-color: var(--color-emerald-400, #34d399);
       color: var(--color-emerald-950, #022c22);
-      padding: 0.5rem 1rem;
+      padding: 0.75rem 1.25rem;
       border-radius: 999px;
       font-size: 0.875rem;
       box-shadow: 0 10px 24px rgba(6, 95, 70, 0.25);


### PR DESCRIPTION
## Summary
- replace the automatic service worker import with a guarded call to the prompt-based registration helper so update prompts show in-page while logging errors in dev
- refactor the PWA helper to expose both silent and prompt registration APIs, add accessible toast semantics, and dispatch an offline signal for the install prompt island

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cd35f36df48324b12dcd5a2ac1edef