### PR TITLE
Enhance PWA install prompt and push messaging

### DIFF
--- a/public/sw-error-handler.js
+++ b/public/sw-error-handler.js
@@ -5,6 +5,122 @@ self.addEventListener('message', (event) => {
   }
 });
 
+// Marketing push campaigns kept in sync with src/lib/pwa/pushCampaigns.ts
+const MARKETING_CAMPAIGNS = [
+  {
+    id: 'booking-reminders',
+    title: 'Viewing confirmed – here\'s what to expect',
+    body: 'Get instant alerts when your preferred viewing slot is confirmed and receive timely reminders so you never miss an appointment.',
+    url: '/#book-viewing',
+    tag: 'booking-updates'
+  },
+  {
+    id: 'insider-guide',
+    title: 'Unlock the Apple Cottage insider guide',
+    body: 'Tap for curated tips on the rooms to explore, hidden garden corners and scenic walks while you plan your visit.',
+    url: '/#highlights',
+    tag: 'insider-guide'
+  },
+  {
+    id: 'arrival-checklist',
+    title: 'Arrival checklist ready for you',
+    body: 'We\'ll nudge you with directions, parking info and Wi-Fi details the day before you travel so arrival is effortless.',
+    url: '/#plan-your-stay',
+    tag: 'arrival-checklist'
+  }
+];
+
+const FALLBACK_NOTIFICATION = {
+  title: 'Apple Cottage updates',
+  body: 'Install the app to receive booking alerts, insider guides and pre-arrival reminders as soon as they drop.',
+  url: '/?source=push-fallback',
+  tag: 'applecottage-default'
+};
+
+const getCampaignById = (id) => MARKETING_CAMPAIGNS.find((campaign) => campaign.id === id);
+
+self.addEventListener('push', (event) => {
+  if (!event) {
+    return;
+  }
+
+  let payload;
+  try {
+    payload = event.data?.json?.();
+  } catch {
+    try {
+      const text = event.data?.text?.();
+      payload = text ? { body: text } : undefined;
+    } catch {
+      payload = undefined;
+    }
+  }
+
+  const campaign = payload?.campaignId ? getCampaignById(payload.campaignId) : undefined;
+  const notificationDetails = campaign ?? {
+    title: payload?.title ?? FALLBACK_NOTIFICATION.title,
+    body: payload?.body ?? FALLBACK_NOTIFICATION.body,
+    url: payload?.url ?? FALLBACK_NOTIFICATION.url,
+    tag: payload?.tag ?? FALLBACK_NOTIFICATION.tag
+  };
+
+  const data = {
+    url: notificationDetails.url,
+    campaignId: campaign?.id ?? payload?.campaignId ?? null,
+    source: payload?.source ?? 'push'
+  };
+
+  const options = {
+    body: notificationDetails.body,
+    tag: notificationDetails.tag,
+    data,
+    icon: '/icons/icon-192.png',
+    badge: '/icons/icon-192.png',
+    vibrate: [200, 100, 200],
+    actions: [
+      {
+        action: 'open',
+        title: 'Open Apple Cottage'
+      }
+    ]
+  };
+
+  event.waitUntil(
+    (async () => {
+      if (!self.registration?.showNotification) {
+        return undefined;
+      }
+      return self.registration.showNotification(notificationDetails.title, options);
+    })()
+  );
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const targetUrl = event.notification?.data?.url ?? '/';
+
+  event.waitUntil(
+    (async () => {
+      const allClients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+      const existingClient = allClients.find((client) => client.url?.includes(self.location.origin));
+
+      if (existingClient?.focus) {
+        await existingClient.focus();
+        if (targetUrl && existingClient.url !== targetUrl && existingClient.navigate) {
+          await existingClient.navigate(targetUrl);
+        }
+        return undefined;
+      }
+
+      if (self.clients.openWindow) {
+        return self.clients.openWindow(targetUrl);
+      }
+
+      return undefined;
+    })()
+  );
+});
+
 // Handle quota exceeded errors
 self.addEventListener('fetch', (event) => {
   if (event.request.method !== 'GET') return;

--- a/src/components/EmbeddedBookingForm.astro
+++ b/src/components/EmbeddedBookingForm.astro
@@ -29,3 +29,22 @@
   <div class="result" role="status" aria-live="polite" style="margin-top:0.5rem"></div>
   <p style="font-size:0.85rem;color:#6b7280;margin-top:0.5rem">Owner-listed. We reply same-day. <a href="/privacy">Privacy & data</a></p>
 </form>
+
+<script is:inline>
+  {`(function(){
+    var form = document.getElementById('book-viewing');
+    if(!form) return;
+    var hasAnnounced = false;
+    function announce(source){
+      if(hasAnnounced) return;
+      hasAnnounced = true;
+      try{
+        window.dispatchEvent(new CustomEvent('applecottage:booking-interest',{ detail:{ source:source }}));
+      }catch(error){
+        console.error('Unable to announce booking intent', error);
+      }
+    }
+    form.addEventListener('focusin', function(){ announce('booking_form'); });
+    form.addEventListener('submit', function(){ announce('booking_form_submission'); });
+  })();`}
+</script>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -97,6 +97,15 @@ if (homeReport?.href) {
   {`(function(){
     var cta = document.getElementById('hero-cta');
     if(!cta) return;
-    cta.addEventListener('click', function(){ try{ if(window.gtag) window.gtag('event','sticky_book_click',{ event_category:'engagement', event_label:'hero_cta' }); }catch(e){} });
+    cta.addEventListener('click', function(){
+      try{
+        if(window.gtag){
+          window.gtag('event','sticky_book_click',{ event_category:'engagement', event_label:'hero_cta' });
+        }
+      }catch(e){ console.error('Unable to push hero CTA analytics event', e); }
+      try{
+        window.dispatchEvent(new CustomEvent('applecottage:booking-interest',{ detail:{ source:'hero_cta' }}));
+      }catch(err){ console.error('Unable to announce booking intent', err); }
+    });
   })();`}
 </script>

--- a/src/components/StickyCTA.astro
+++ b/src/components/StickyCTA.astro
@@ -349,10 +349,23 @@
       }
     }
 
+    function signalBookingInterest(source) {
+      try {
+        window?.dispatchEvent(
+          new CustomEvent('applecottage:booking-interest', {
+            detail: { source }
+          })
+        );
+      } catch (error) {
+        console.error('Unable to announce booking intent', error);
+      }
+    }
+
     var bookButton = document.getElementById('sticky-book');
     if (bookButton) {
       bookButton.addEventListener('click', function () {
         sendEvent('sticky_book_click');
+        signalBookingInterest('sticky_cta');
       });
     }
 

--- a/src/components/a2hs/InstallPromptIsland.tsx
+++ b/src/components/a2hs/InstallPromptIsland.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef } from 'react';
+import { installValuePropositions } from '../../lib/pwa/pushCampaigns';
 import { useA2HS } from './useA2HS';
 
 export default function InstallPromptIsland(): JSX.Element | null {
@@ -12,6 +13,7 @@ export default function InstallPromptIsland(): JSX.Element | null {
     registerGalleryView,
     registerTourWatch,
     registerOfflineDownload,
+    registerBookingIntent,
   } = useA2HS();
 
   const installButtonRef = useRef<HTMLButtonElement>(null);
@@ -24,6 +26,8 @@ export default function InstallPromptIsland(): JSX.Element | null {
         return 'Enjoying the virtual tour? Install the app for quick, offline-friendly access to every room.';
       case 'offline':
         return 'Offline access unlocked — install the app so the full experience is just a tap away.';
+      case 'booking':
+        return 'Lock in booking updates, reminders and insider property tips directly on your home screen.';
       default:
         return 'Install Apple Cottage on your device for faster access and offline viewing.';
     }
@@ -62,30 +66,40 @@ export default function InstallPromptIsland(): JSX.Element | null {
       registerOfflineDownload();
     };
 
+    const handleBookingIntent = () => {
+      registerBookingIntent();
+    };
+
     window.addEventListener('applecottage:gallery-viewed', handleGalleryViewed as EventListener);
     window.addEventListener('applecottage:tour-watch', handleTourWatch as EventListener);
     window.addEventListener('applecottage:offline-download', handleOfflineDownload);
+    window.addEventListener('applecottage:booking-interest', handleBookingIntent);
 
     return () => {
       window.removeEventListener('applecottage:gallery-viewed', handleGalleryViewed as EventListener);
       window.removeEventListener('applecottage:tour-watch', handleTourWatch as EventListener);
       window.removeEventListener('applecottage:offline-download', handleOfflineDownload);
+      window.removeEventListener('applecottage:booking-interest', handleBookingIntent);
     };
-  }, [registerGalleryView, registerTourWatch, registerOfflineDownload]);
+  }, [registerGalleryView, registerTourWatch, registerOfflineDownload, registerBookingIntent]);
 
   if (!isSupported || !canInstall || !isPromptVisible) {
     return null;
   }
 
+  const listId = 'a2hs-benefits';
+  const descriptionId = 'a2hs-description';
+
   return (
-    <div className="fixed bottom-4 right-4 z-[2147483646] flex flex-col items-end gap-3" aria-live="polite">
-      <div
+    <section className="fixed bottom-4 right-4 z-[2147483646] flex flex-col items-end gap-3" aria-live="polite">
+      <article
         role="dialog"
         aria-modal="false"
         aria-labelledby="a2hs-title"
+        aria-describedby={`${descriptionId} ${listId}`}
         className="max-w-sm rounded-2xl bg-white shadow-2xl border border-slate-200 p-4 sm:p-5 text-slate-900 focus-within:ring-2 focus-within:ring-blue-500"
       >
-        <div className="flex items-start gap-3">
+        <header className="flex items-start gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 text-white" aria-hidden="true">
             📱
           </div>
@@ -93,12 +107,17 @@ export default function InstallPromptIsland(): JSX.Element | null {
             <h2 id="a2hs-title" className="text-lg font-semibold mb-1">
               Install Apple Cottage
             </h2>
-            <p className="text-sm text-slate-600 leading-relaxed">
+            <p id={descriptionId} className="text-sm text-slate-600 leading-relaxed">
               {message}
             </p>
           </div>
-        </div>
-        <div className="mt-4 flex flex-wrap gap-2 justify-end">
+        </header>
+        <ul id={listId} className="mt-3 list-disc pl-5 text-sm text-slate-600 space-y-2">
+          {installValuePropositions.slice(0, 3).map((valueProp) => (
+            <li key={valueProp}>{valueProp}</li>
+          ))}
+        </ul>
+        <footer className="mt-4 flex flex-wrap gap-2 justify-end">
           <button
             type="button"
             className="rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1"
@@ -116,8 +135,8 @@ export default function InstallPromptIsland(): JSX.Element | null {
           >
             Install now
           </button>
-        </div>
-      </div>
-    </div>
+        </footer>
+      </article>
+    </section>
   );
 }

--- a/src/components/a2hs/useA2HS.ts
+++ b/src/components/a2hs/useA2HS.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 const GALLERY_VIEW_THRESHOLD = 5;
 const TOUR_SECONDS_THRESHOLD = 60;
 
-type TriggerReason = 'gallery' | 'tour' | 'offline';
+type TriggerReason = 'gallery' | 'tour' | 'offline' | 'booking';
 
 interface BeforeInstallPromptEvent extends Event {
   readonly platforms?: string[];
@@ -46,10 +46,14 @@ export const useA2HS = () => {
   const galleryViewsRef = useRef<Set<string>>(new Set());
   const tourSecondsRef = useRef<number>(0);
   const offlineTriggeredRef = useRef<boolean>(false);
+  const bookingIntentRef = useRef<boolean>(false);
 
   const getTriggerReason = useCallback((): TriggerReason | null => {
     if (!deferredPrompt || dismissed) {
       return null;
+    }
+    if (bookingIntentRef.current) {
+      return 'booking';
     }
     if (offlineTriggeredRef.current) {
       return 'offline';
@@ -122,6 +126,11 @@ export const useA2HS = () => {
     evaluatePromptVisibility();
   }, [evaluatePromptVisibility]);
 
+  const registerBookingIntent = useCallback(() => {
+    bookingIntentRef.current = true;
+    evaluatePromptVisibility();
+  }, [evaluatePromptVisibility]);
+
   const showPrompt = useCallback(async () => {
     const promptEvent = deferredPrompt;
     if (!promptEvent) {
@@ -159,6 +168,7 @@ export const useA2HS = () => {
     registerGalleryView,
     registerTourWatch,
     registerOfflineDownload,
+    registerBookingIntent,
   };
 };
 

--- a/src/lib/pwa/pushCampaigns.ts
+++ b/src/lib/pwa/pushCampaigns.ts
@@ -1,0 +1,55 @@
+export interface PushCampaign {
+  id: string;
+  title: string;
+  body: string;
+  /**
+   * Optional call-to-action label displayed within supported notification UI.
+   * Browsers expose this via actions or when opening a landing page.
+   */
+  cta?: string;
+  /**
+   * Landing page path opened when the notification is tapped.
+   * Should be a relative URL so the PWA can route offline.
+   */
+  url?: string;
+  /**
+   * Marketing persona or trigger the campaign is designed for.
+   */
+  segment: 'booking' | 'research' | 'stay-prep';
+  /**
+   * High-level benefit statement to surface in install messaging.
+   */
+  valueProp: string;
+}
+
+export const pushCampaigns: PushCampaign[] = [
+  {
+    id: 'booking-reminders',
+    title: 'Viewing confirmed – here\'s what to expect',
+    body: 'We\'ll send you a heads-up as soon as your preferred slot is confirmed and follow up with reminders so nothing slips through.',
+    cta: 'Review your viewing plan',
+    url: '/#book-viewing',
+    segment: 'booking',
+    valueProp: 'Stay on top of viewing confirmations and get real-time schedule updates.'
+  },
+  {
+    id: 'insider-guide',
+    title: 'Unlock the Apple Cottage insider guide',
+    body: 'Receive hand-picked tips about the best rooms to explore, hidden garden corners and nearby walks tailored to your stay.',
+    cta: 'See the guide highlights',
+    url: '/#highlights',
+    segment: 'research',
+    valueProp: 'Get insider property tips and local recommendations delivered instantly.'
+  },
+  {
+    id: 'arrival-checklist',
+    title: 'Arrival checklist ready for you',
+    body: 'We\'ll nudge you with directions, parking details and Wi-Fi info the day before you travel so arrival is stress-free.',
+    cta: 'Open the pre-arrival checklist',
+    url: '/#plan-your-stay',
+    segment: 'stay-prep',
+    valueProp: 'Receive pre-arrival reminders with directions, access codes and insider tips.'
+  }
+];
+
+export const installValuePropositions = pushCampaigns.map((campaign) => campaign.valueProp);


### PR DESCRIPTION
## Summary
- enrich the install prompt with campaign-backed benefit messaging and booking-specific copy
- instrument booking intent signals across the hero CTA, sticky CTA, and booking form to trigger the prompt
- define marketing push campaigns and surface them in the service worker for proactive notifications

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68d11603c6888324871c7863256b3e1a