### PR TITLE
Fix property portal URLs and streamline portal handling

### DIFF
--- a/site.config.ts
+++ b/site.config.ts
@@ -52,7 +52,7 @@ export const site = {
   siteUrl: 'https://applecottagecreetown.co.uk',
   address: 'Apple Cottage, Creetown, Scotland',
   coordinates: { lat: 54.899611, lng: -4.380458 },
-  bookingUrl: 'https://www.williamsonandhenry.co.uk/property/apple-cottage-creetown/',
+  bookingUrl: 'https://www.williamsonandhenry.co.uk/property/apple-cottage-silver-street-creetown/',
   price: '💰 Offers Over £300,000',
   bedrooms: '🛏️ 3 Double Bedrooms',
   bathrooms: '🛁 1 + Downstairs WC',
@@ -321,11 +321,13 @@ export const site = {
     ]
   },
   portals: {
-    williamsonhenry: 'https://www.williamsonandhenry.co.uk/property/apple-cottage-creetown/'
+    williamsonhenry: 'https://www.williamsonandhenry.co.uk/property/apple-cottage-silver-street-creetown/',
+    rightmove: 'https://www.rightmove.co.uk/properties/167887832',
+    zoopla: 'https://www.zoopla.co.uk/for-sale/details/71499152/'
   },
   docs: [
     { label: 'Plot Plan', href: OVERRIDES.PLOT_IMAGE_URL || media('/docs/plot.png') },
-    { label: 'Home Report', href: OVERRIDES.HOME_REPORT_URL || 'https://www.williamsonandhenry.co.uk/property/apple-cottage-creetown/' },
+    { label: 'Home Report', href: OVERRIDES.HOME_REPORT_URL || 'https://www.williamsonandhenry.co.uk/property/apple-cottage-silver-street-creetown/' },
     { label: 'Planning Permission', href: `${DEFAULT_CDN}/docs/planning-permission.png` }
   ]
 };

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,7 +1,10 @@
 ---
 import site from '../../site.config';
+import { getAvailablePortals } from '../lib/portals';
+
 const hero = site.hero || {};
 const homeReport = (site.docs || []).find?.((d) => /home\s*report/i.test(d.label || ''));
+const heroPortals = getAvailablePortals(site.portals);
 
 function formatBytes(bytes: number) {
   if (!Number.isFinite(bytes) || bytes <= 0) return null;
@@ -60,17 +63,22 @@ if (homeReport?.href) {
           </a>
         )}
       </div>
-      {site.portals?.williamsonhenry && (
+      {heroPortals.length > 0 && (
         <div class="mt-3 flex flex-wrap justify-center gap-2" aria-label="External property links">
-          <a
-            id="hero-portal-link"
-            href={site.portals.williamsonhenry}
-            target="_blank"
-            rel="noopener"
-            class="px-3 py-1 rounded-full bg-white/90 text-gray-800 hover:bg-white focus:outline-none focus-visible:ring"
-          >
-            View on Williamson & Henry
-          </a>
+          {heroPortals.map((portal) => (
+            <a
+              id={`hero-portal-${portal.key}`}
+              href={portal.href}
+              target="_blank"
+              rel="noopener"
+              class="px-3 py-1 rounded-full bg-white/90 text-gray-800 hover:bg-white focus:outline-none focus-visible:ring"
+              aria-label={portal.ariaLabel}
+              data-hero-portal={portal.key}
+              data-portal-name={portal.label}
+            >
+              View on {portal.label}
+            </a>
+          ))}
         </div>
       )}
     </div>
@@ -139,26 +147,30 @@ if (homeReport?.href) {
   })();`}
 </script>
 
-{site.portals?.williamsonhenry && (
+{heroPortals.length > 0 && (
   <script is:inline>
     {`(function(){
-      var portal = document.getElementById('hero-portal-link');
-      if (!portal) return;
-      portal.addEventListener('click', function(){
-        var href = portal.getAttribute('href');
-        try {
-          if (window.appleAnalytics && typeof window.appleAnalytics.trackCta === 'function') {
-            window.appleAnalytics.trackCta({
-              name: 'View on Williamson & Henry',
-              location: 'hero',
-              destination: href,
-              type: 'external',
-              variant: 'hero-portal'
-            });
+      var links = document.querySelectorAll('[data-hero-portal]');
+      if (!links || links.length === 0) return;
+      Array.prototype.forEach.call(links, function(portal){
+        portal.addEventListener('click', function(){
+          var href = portal.getAttribute('href');
+          var label = portal.getAttribute('data-portal-name') || 'External portal';
+          if (!href) return;
+          try {
+            if (window.appleAnalytics && typeof window.appleAnalytics.trackCta === 'function') {
+              window.appleAnalytics.trackCta({
+                name: label,
+                location: 'hero',
+                destination: href,
+                type: 'external',
+                variant: 'hero-portal'
+              });
+            }
+          } catch (analyticsError) {
+            console.warn('Hero portal CTA tracking failed', analyticsError);
           }
-        } catch (analyticsError) {
-          console.warn('Hero portal CTA tracking failed', analyticsError);
-        }
+        });
       });
     })();`}
   </script>

--- a/src/components/QuickContactStrip.astro
+++ b/src/components/QuickContactStrip.astro
@@ -1,8 +1,10 @@
 ---
 import site from '../../site.config';
+import { getAvailablePortals } from '../lib/portals';
+
 const phone = site.contact?.phone || '';
 const email = site.contact?.email || '';
-const portals = site.portals || {};
+const portalLinks = getAvailablePortals(site.portals);
 function digits(s: string) { return s.replace(/\D/g, ''); }
 const telHref = phone ? `tel:${phone.replace(/\s/g, '')}` : null;
 const waHref = phone ? `https://wa.me/${digits(phone)}?text=${encodeURIComponent('Hello, I am interested in Apple Cottage in Creetown.')}` : null;
@@ -15,9 +17,17 @@ const mailHref = email ? `mailto:${email}?subject=${encodeURIComponent('Apple Co
       {telHref && <a href={telHref} class="px-2 py-1 rounded border hover:bg-gray-50" aria-label={`Call ${phone}`}>Call</a>}
       {waHref && <a href={waHref} target="_blank" rel="noopener" class="px-2 py-1 rounded border hover:bg-gray-50" aria-label="Chat on WhatsApp">WhatsApp</a>}
       {mailHref && <a href={mailHref} class="px-2 py-1 rounded border hover:bg-gray-50" aria-label={`Email ${email}`}>Email</a>}
-      {portals?.williamsonhenry && (
-        <a href={portals.williamsonhenry} target="_blank" rel="noopener" class="px-2 py-1 rounded border hover:bg-gray-50" aria-label="View on Williamson & Henry">Williamson & Henry</a>
-      )}
+      {portalLinks.map((portal) => (
+        <a
+          href={portal.href}
+          target="_blank"
+          rel="noopener"
+          class="px-2 py-1 rounded border hover:bg-gray-50"
+          aria-label={portal.ariaLabel}
+        >
+          {portal.label}
+        </a>
+      ))}
     </div>
   </div>
 </nav>

--- a/src/components/ScotlandProcess.astro
+++ b/src/components/ScotlandProcess.astro
@@ -1,6 +1,24 @@
 ---
+import site from '../../site.config';
+
+const homeReportDoc = (site.docs || []).find?.((doc) => /home\s*report/i.test(doc.label ?? ''));
+const normalizedHomeReport = typeof homeReportDoc?.href === 'string' ? homeReportDoc.href.trim() : '';
+const homeReportUrl = normalizedHomeReport || (site.portals?.williamsonhenry?.trim?.() ?? '');
+const hasHomeReport = homeReportUrl.length > 0;
+const homeReportTarget = hasHomeReport && /^https?:/i.test(homeReportUrl) ? '_blank' : undefined;
+const homeReportRel = homeReportTarget ? 'noopener' : undefined;
 ---
 <section aria-labelledby="scotland-process" class="prose mx-auto p-4">
   <h2 id="scotland-process">Buying in Scotland — how it works</h2>
-  <p>Ask your solicitor to <strong>note interest</strong> if you’re keen; we’ll notify all noted parties if a <strong>closing date</strong> is set. The <a href="https://www.williamsonandhenry.co.uk/property/apple-cottage-creetown/" target="_blank" rel="noopener">Home Report</a> (survey, valuation and EPC) is available to download at any time. For full guidance, see <a href="https://www.mygov.scot/buying-a-home/home-report">MyGov Scotland</a>.</p>
+  <p>
+    Ask your solicitor to <strong>note interest</strong> if you’re keen; we’ll notify all noted parties if a <strong>closing date</strong> is set.
+    The
+    {hasHomeReport ? (
+      <a href={homeReportUrl} target={homeReportTarget} rel={homeReportRel}>Home Report</a>
+    ) : (
+      <span>Home Report</span>
+    )}
+    (survey, valuation and EPC) is available to download at any time.
+    For full guidance, see <a href="https://www.mygov.scot/buying-a-home/home-report">MyGov Scotland</a>.
+  </p>
 </section>

--- a/src/components/StickyCTA.astro
+++ b/src/components/StickyCTA.astro
@@ -6,6 +6,21 @@ const shareText = site.description
   ? `${site.title ?? 'Apple Cottage'} — ${site.description}`
   : site.title ?? 'Apple Cottage';
 const shareUrl = site.siteUrl ?? 'https://applecottagecreetown.co.uk';
+
+const normalizedBooking = typeof site.bookingUrl === 'string' ? site.bookingUrl.trim() : '';
+const fallbackBooking = site.portals?.williamsonhenry?.trim?.() || '#book-viewing';
+const bookingUrl = normalizedBooking.length > 0 ? normalizedBooking : fallbackBooking;
+const isExternalBooking = /^https?:/i.test(bookingUrl);
+const bookingTarget = isExternalBooking ? '_blank' : undefined;
+const bookingRel = isExternalBooking ? 'noopener' : undefined;
+
+const homeReportDoc = (site.docs || []).find?.((doc) => /home\s*report/i.test(doc.label ?? ''));
+const normalizedHomeReport = typeof homeReportDoc?.href === 'string' ? homeReportDoc.href.trim() : '';
+const homeReportUrl = normalizedHomeReport || (site.portals?.williamsonhenry?.trim?.() ?? '');
+const hasHomeReportLink = homeReportUrl.length > 0;
+const homeReportIsExternal = hasHomeReportLink ? /^https?:/i.test(homeReportUrl) : false;
+const homeReportTarget = homeReportIsExternal ? '_blank' : undefined;
+const homeReportRel = homeReportIsExternal ? 'noopener' : undefined;
 ---
 <!-- Refined sticky CTA bar optimised for mobile + desktop -->
 <style>
@@ -276,9 +291,9 @@ const shareUrl = site.siteUrl ?? 'https://applecottagecreetown.co.uk';
   </div>
   <div class="sticky-cta__actions">
     <a
-      href="https://www.williamsonandhenry.co.uk/property/apple-cottage-creetown/"
-      target="_blank"
-      rel="noopener"
+      href={bookingUrl}
+      target={bookingTarget}
+      rel={bookingRel}
       class="sticky-cta__button sticky-cta__button--primary"
       id="sticky-book"
     >
@@ -323,40 +338,42 @@ const shareUrl = site.siteUrl ?? 'https://applecottagecreetown.co.uk';
       </span>
       Book a Viewing
     </a>
-    <a
-      href="https://www.williamsonandhenry.co.uk/property/apple-cottage-creetown/"
-      target="_blank"
-      rel="noopener"
-      class="sticky-cta__button sticky-cta__button--secondary"
-      id="sticky-hr"
-    >
-      <span class="sticky-cta__icon" aria-hidden="true">
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path
-            d="M12 3V17"
-            stroke="currentColor"
-            stroke-width="1.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-          <path
-            d="M7 12L12 17L17 12"
-            stroke="currentColor"
-            stroke-width="1.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-          <path
-            d="M5 21H19"
-            stroke="currentColor"
-            stroke-width="1.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-        </svg>
-      </span>
-      Download Home Report
-    </a>
+    {hasHomeReportLink && (
+      <a
+        href={homeReportUrl}
+        target={homeReportTarget}
+        rel={homeReportRel}
+        class="sticky-cta__button sticky-cta__button--secondary"
+        id="sticky-hr"
+      >
+        <span class="sticky-cta__icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path
+              d="M12 3V17"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+            <path
+              d="M7 12L12 17L17 12"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+            <path
+              d="M5 21H19"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </span>
+        Download Home Report
+      </a>
+    )}
     <a
       href="https://wa.me/447931071401"
       class="sticky-cta__button sticky-cta__button--whatsapp"
@@ -499,8 +516,11 @@ const shareUrl = site.siteUrl ?? 'https://applecottagecreetown.co.uk';
     var bookButton = document.getElementById('sticky-book');
     if (bookButton) {
       bookButton.addEventListener('click', function () {
-        trackCtaInteraction('Book Viewing', bookButton.getAttribute('href'), 'external', 'sticky-book');
-        trackContact('external_booking', bookButton.getAttribute('href'));
+        var href = bookButton.getAttribute('href') || '#book-viewing';
+        var type = href.indexOf('#') === 0 ? 'internal_anchor' : 'external';
+        trackCtaInteraction('Book Viewing', href, type, 'sticky-book');
+        var contactType = type === 'external' ? 'external_booking' : 'internal_booking';
+        trackContact(contactType, href);
         signalBookingInterest('sticky_cta');
       });
     }
@@ -509,6 +529,7 @@ const shareUrl = site.siteUrl ?? 'https://applecottagecreetown.co.uk';
     if (reportButton) {
       reportButton.addEventListener('click', function () {
         var href = reportButton.getAttribute('href');
+        if (!href) return;
         trackCtaInteraction('Home Report', href, 'document', 'sticky-home-report');
         trackDocumentOpen('Home Report', href, 'pdf');
       });

--- a/src/components/TrustBar.astro
+++ b/src/components/TrustBar.astro
@@ -1,4 +1,13 @@
 ---
+import site from '../../site.config';
+
+const homeReportDoc = (site.docs || []).find?.((doc) => /home\s*report/i.test(doc.label ?? ''));
+const normalizedHomeReport = typeof homeReportDoc?.href === 'string' ? homeReportDoc.href.trim() : '';
+const homeReportUrl = normalizedHomeReport || (site.portals?.williamsonhenry?.trim?.() ?? '');
+const hasHomeReportLink = homeReportUrl.length > 0;
+const homeReportTarget = hasHomeReportLink && /^https?:/i.test(homeReportUrl) ? '_blank' : undefined;
+const homeReportRel = homeReportTarget ? 'noopener' : undefined;
+const homeReportAria = 'View property details and home report';
 ---
 <style>
   .trustbar {
@@ -107,9 +116,20 @@
       <p class="trust-eyebrow">Independent Survey</p>
       <p class="trust-title">Download the Home Report</p>
       <p class="trust-description">
-        <a class="trust-link" id="trustbar-home-report" href="https://www.williamsonandhenry.co.uk/property/apple-cottage-creetown/" target="_blank" rel="noopener" aria-label="View property details and home report">
-          Valuation £300,000
-        </a>
+        {hasHomeReportLink ? (
+          <a
+            class="trust-link"
+            id="trustbar-home-report"
+            href={homeReportUrl}
+            target={homeReportTarget}
+            rel={homeReportRel}
+            aria-label={homeReportAria}
+          >
+            Valuation £300,000
+          </a>
+        ) : (
+          <span>Valuation £300,000</span>
+        )}
       </p>
     </div>
   </article>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -3,20 +3,20 @@ type AnalyticsEvent = {
   params?: Record<string, unknown>;
 };
 
-declare global {
-  interface Window {
-    appleAnalytics?: {
-      trackEvent: (eventName: string, params?: Record<string, unknown>) => void;
-    };
-    __appleAnalyticsQueue?: AnalyticsEvent[];
-  }
+interface AnalyticsApi {
+  trackEvent: Function;
 }
+
+type AnalyticsWindow = Window & {
+  appleAnalytics?: AnalyticsApi;
+  __appleAnalyticsQueue?: AnalyticsEvent[];
+};
 
 const QUEUE_KEY = '__appleAnalyticsQueue';
 
 const enqueue = (eventName: string, params?: Record<string, unknown>) => {
   if (typeof window === 'undefined') return;
-  const w = window as Window;
+  const w = window as AnalyticsWindow;
   if (!Array.isArray(w[QUEUE_KEY])) {
     w[QUEUE_KEY] = [];
   }
@@ -25,7 +25,7 @@ const enqueue = (eventName: string, params?: Record<string, unknown>) => {
 
 const dispatchThroughGlobal = (eventName: string, params?: Record<string, unknown>) => {
   if (typeof window === 'undefined') return false;
-  const w = window as Window;
+  const w = window as AnalyticsWindow;
   if (w.appleAnalytics?.trackEvent) {
     try {
       w.appleAnalytics.trackEvent(eventName, params);
@@ -156,7 +156,7 @@ export const trackBookingInterest = (details: { source?: string }) => {
 
 export const flushAnalyticsQueue = () => {
   if (typeof window === 'undefined') return;
-  const w = window as Window;
+  const w = window as AnalyticsWindow;
   const queue = w[QUEUE_KEY];
   if (!Array.isArray(queue) || queue.length === 0) return;
   if (!w.appleAnalytics?.trackEvent) return;

--- a/src/lib/portals.ts
+++ b/src/lib/portals.ts
@@ -1,0 +1,55 @@
+export type PortalKey = 'williamsonhenry' | 'rightmove' | 'zoopla';
+
+export interface PortalDefinition {
+  key: PortalKey;
+  label: string;
+  ariaLabel: string;
+}
+
+export interface PortalEntry extends PortalDefinition {
+  href: string;
+}
+
+const portalDefinitions: PortalDefinition[] = [
+  {
+    key: 'williamsonhenry',
+    label: 'Williamson & Henry',
+    ariaLabel: 'View on Williamson & Henry'
+  },
+  {
+    key: 'rightmove',
+    label: 'Rightmove',
+    ariaLabel: 'View on Rightmove'
+  },
+  {
+    key: 'zoopla',
+    label: 'Zoopla',
+    ariaLabel: 'View on Zoopla'
+  }
+];
+
+type PortalRecord = Partial<Record<PortalKey, string | null | undefined>> | undefined | null;
+
+function isValidHref(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  return trimmed.length > 0;
+}
+
+export function getAvailablePortals(portals: PortalRecord): PortalEntry[] {
+  if (!portals) return [];
+
+  return portalDefinitions.flatMap((definition) => {
+    const href = portals?.[definition.key];
+    if (!isValidHref(href)) return [];
+    const trimmedHref = href.trim();
+    return [
+      {
+        ...definition,
+        href: trimmedHref
+      }
+    ];
+  });
+}
+
+export default portalDefinitions;


### PR DESCRIPTION
## Summary
- correct the Williamson & Henry booking URL and add the supplied Rightmove and Zoopla listings in site configuration
- reuse the new portal helper across hero and quick contact UI so the external buttons stay in sync with config and analytics tracking
- update sticky CTAs and informational copy to source the home report link from config while keeping lint checks passing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e4f83f4e08832495012d8290f51199