### PR TITLE
Replace WhatsApp CTAs with SMS “Message Seller” and enrich analytics tracking

### DIFF
--- a/src/components/QuickContactStrip.astro
+++ b/src/components/QuickContactStrip.astro
@@ -7,7 +7,8 @@ const email = site.contact?.email || '';
 const portalLinks = getAvailablePortals(site.portals);
 function digits(s: string) { return s.replace(/\D/g, ''); }
 const telHref = phone ? `tel:${phone.replace(/\s/g, '')}` : null;
-const waHref = phone ? `https://wa.me/${digits(phone)}?text=${encodeURIComponent('Hello, I am interested in Apple Cottage in Creetown.')}` : null;
+const smsBody = 'Hello, I am interested in Apple Cottage in Creetown.';
+const smsHref = phone ? `sms:${digits(phone)}?body=${encodeURIComponent(smsBody)}` : null;
 const mailHref = email ? `mailto:${email}?subject=${encodeURIComponent('Apple Cottage viewing')}` : null;
 ---
 <nav aria-label="Quick contact" class="w-full bg-white/90 backdrop-blur sticky top-0 z-40 border-b">
@@ -15,7 +16,7 @@ const mailHref = email ? `mailto:${email}?subject=${encodeURIComponent('Apple Co
     <div class="font-medium">Apple Cottage</div>
     <div class="flex items-center gap-2">
       {telHref && <a href={telHref} class="px-2 py-1 rounded border hover:bg-gray-50" aria-label={`Call ${phone}`}>Call</a>}
-      {waHref && <a href={waHref} target="_blank" rel="noopener" class="px-2 py-1 rounded border hover:bg-gray-50" aria-label="Chat on WhatsApp">WhatsApp</a>}
+      {smsHref && <a href={smsHref} class="px-2 py-1 rounded border hover:bg-gray-50" aria-label="Message the seller by SMS">Message Seller</a>}
       {mailHref && <a href={mailHref} class="px-2 py-1 rounded border hover:bg-gray-50" aria-label={`Email ${email}`}>Email</a>}
       {portalLinks.map((portal) => (
         <a
@@ -31,4 +32,3 @@ const mailHref = email ? `mailto:${email}?subject=${encodeURIComponent('Apple Co
     </div>
   </div>
 </nav>
-

--- a/src/components/StickyCTA.astro
+++ b/src/components/StickyCTA.astro
@@ -14,6 +14,10 @@ const isExternalBooking = /^https?:/i.test(bookingUrl);
 const bookingTarget = isExternalBooking ? '_blank' : undefined;
 const bookingRel = isExternalBooking ? 'noopener' : undefined;
 
+const sellerPhone = (site.contact?.phone ?? '447931071401').replace(/\D/g, '');
+const smsMessage = 'Hello, I am interested in Apple Cottage in Creetown.';
+const smsHref = sellerPhone ? `sms:${sellerPhone}?body=${encodeURIComponent(smsMessage)}` : '#';
+
 const homeReportDoc = (site.docs || []).find?.((doc) => /home\s*report/i.test(doc.label ?? ''));
 const normalizedHomeReport = typeof homeReportDoc?.href === 'string' ? homeReportDoc.href.trim() : '';
 const homeReportUrl = normalizedHomeReport || '';
@@ -184,10 +188,10 @@ const homeReportRel = homeReportIsExternal ? 'noopener' : undefined;
     border: 1px solid rgba(148, 163, 184, 0.25);
   }
 
-  .sticky-cta__button--whatsapp {
-    background: rgba(34, 197, 94, 0.1);
-    color: #166534;
-    border: 1px solid rgba(34, 197, 94, 0.3);
+  .sticky-cta__button--message {
+    background: rgba(59, 130, 246, 0.12);
+    color: #1d4ed8;
+    border: 1px solid rgba(59, 130, 246, 0.3);
   }
 
   .sticky-cta__button--share {
@@ -214,10 +218,10 @@ const homeReportRel = homeReportIsExternal ? 'noopener' : undefined;
     color: #1f2937;
   }
 
-  .sticky-cta__button--whatsapp:hover,
-  .sticky-cta__button--whatsapp:focus-visible {
-    background: rgba(34, 197, 94, 0.15);
-    border-color: rgba(34, 197, 94, 0.4);
+  .sticky-cta__button--message:hover,
+  .sticky-cta__button--message:focus-visible {
+    background: rgba(59, 130, 246, 0.18);
+    border-color: rgba(59, 130, 246, 0.4);
   }
 
   .sticky-cta__button--share:hover,
@@ -405,30 +409,29 @@ const homeReportRel = homeReportIsExternal ? 'noopener' : undefined;
       </a>
     )}
     <a
-      href="https://wa.me/447931071401"
-      class="sticky-cta__button sticky-cta__button--whatsapp"
-      aria-label="Open WhatsApp chat with the Apple Cottage owner"
-      id="sticky-wa"
+      href={smsHref}
+      class="sticky-cta__button sticky-cta__button--message"
+      aria-label="Send an SMS to the Apple Cottage owner"
+      id="sticky-sms"
     >
       <span class="sticky-cta__icon" aria-hidden="true">
         <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path
-            d="M3 20L4.2 16.2C3.4 14.9 3 13.5 3 12C3 7.6 6.6 4 11 4C15.4 4 19 7.6 19 12C19 16.4 15.4 20 11 20C9.6 20 8.2 19.6 7 18.9L3 20Z"
+            d="M8 19L4 20L5 16C3.7 14.6 3 12.8 3 11C3 6.6 7 3 12 3C17 3 21 6.6 21 11C21 15.4 17 19 12 19H8Z"
             stroke="currentColor"
             stroke-width="1.5"
             stroke-linecap="round"
             stroke-linejoin="round"
           />
           <path
-            d="M9.5 9.5C9.5 9.5 9 8 8.5 8C8 8 7 8.2 7 9.8C7 11.4 8.4 13.1 8.6 13.4C8.8 13.7 9.9 15.3 11.6 16C12.6 16.4 13.2 16.4 13.6 16.3C14 16.2 15 15.7 15.1 15.2C15.2 14.7 15.2 14.2 14.9 14C14.6 13.8 13.6 13.3 13.3 13.2C13 13.1 12.7 13.2 12.5 13.5C12.2 13.9 11.8 14.4 11.6 14.3C11.4 14.2 10.5 13.8 9.9 13.2C9.3 12.6 9 11.7 8.9 11.5C8.8 11.3 9.1 11.1 9.3 10.8C9.5 10.5 9.6 10.3 9.7 10.1C9.8 9.9 9.7 9.7 9.6 9.6C9.4 9.4 9.5 9.5 9.5 9.5Z"
+            d="M8 11H8.01M12 11H12.01M16 11H16.01"
             stroke="currentColor"
             stroke-width="1.5"
             stroke-linecap="round"
-            stroke-linejoin="round"
           />
         </svg>
       </span>
-      WhatsApp Seller
+      Message Seller
     </a>
     <button
       type="button"
@@ -565,12 +568,12 @@ const homeReportRel = homeReportIsExternal ? 'noopener' : undefined;
       });
     }
 
-    var whatsappButton = document.getElementById('sticky-wa');
-    if (whatsappButton) {
-      whatsappButton.addEventListener('click', function () {
-        var href = whatsappButton.getAttribute('href');
-        trackCtaInteraction('WhatsApp Seller', href, 'whatsapp', 'sticky-whatsapp');
-        trackContact('whatsapp', href);
+    var smsButton = document.getElementById('sticky-sms');
+    if (smsButton) {
+      smsButton.addEventListener('click', function () {
+        var href = smsButton.getAttribute('href');
+        trackCtaInteraction('Message Seller', href, 'sms', 'sticky-sms');
+        trackContact('sms', href);
       });
     }
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -81,9 +81,17 @@ const gaId = site.analyticsId;
             return false;
           };
 
+          const getPageContext = () => compact({
+            page_location: win?.location?.href,
+            page_path: win?.location?.pathname,
+            page_title: document?.title,
+            page_referrer: document?.referrer || undefined,
+            page_hostname: win?.location?.hostname,
+          });
+
           const trackEvent = (eventName, params) => {
             if (!eventName) return;
-            const payload = compact(params || {});
+            const payload = compact(Object.assign({}, getPageContext(), params || {}));
             pushToDataLayer(eventName, payload);
             if (!sendWithGtag(eventName, payload)) {
               queue.push({ name: eventName, params: payload });
@@ -169,6 +177,8 @@ const gaId = site.analyticsId;
 
           win.appleAnalytics = api;
 
+          trackEvent('page_view', { engagement_location: 'site' });
+
           win.addEventListener('applecottage:booking-interest', (event) => {
             const source = event?.detail?.source || 'unknown';
             api.trackBookingInterest({ source });
@@ -201,6 +211,85 @@ const gaId = site.analyticsId;
           win.addEventListener('applecottage:offline-download', () => {
             api.trackEvent('offline_download', { engagement_location: 'pwa' });
           }, { passive: true });
+
+          const scrollMilestones = [25, 50, 75, 90];
+          const reachedMilestones = new Set();
+          let scrollTicking = false;
+
+          const handleScrollDepth = () => {
+            if (scrollTicking) return;
+            scrollTicking = true;
+            win.requestAnimationFrame(() => {
+              const doc = document.documentElement;
+              const scrollTop = win.scrollY || doc.scrollTop || 0;
+              const docHeight = doc.scrollHeight || 0;
+              const viewportHeight = win.innerHeight || doc.clientHeight || 0;
+              const maxScroll = Math.max(docHeight - viewportHeight, 1);
+              const percent = Math.min(100, Math.round((scrollTop / maxScroll) * 100));
+
+              scrollMilestones.forEach((milestone) => {
+                if (percent >= milestone && !reachedMilestones.has(milestone)) {
+                  reachedMilestones.add(milestone);
+                  trackEvent('scroll_depth', {
+                    scroll_percent: milestone,
+                    scroll_location: win?.location?.pathname,
+                  });
+                }
+              });
+
+              if (reachedMilestones.size === scrollMilestones.length) {
+                win.removeEventListener('scroll', handleScrollDepth);
+              }
+              scrollTicking = false;
+            });
+          };
+
+          win.addEventListener('scroll', handleScrollDepth, { passive: true });
+
+          const pageStart = Date.now();
+          let timeReported = false;
+
+          const reportTimeOnPage = (reason) => {
+            if (timeReported) return;
+            const seconds = Math.round((Date.now() - pageStart) / 1000);
+            if (seconds <= 0) return;
+            timeReported = true;
+            trackEvent('time_on_page', {
+              engagement_seconds: seconds,
+              engagement_reason: reason,
+            });
+          };
+
+          win.addEventListener('visibilitychange', () => {
+            if (document?.visibilityState === 'hidden') {
+              reportTimeOnPage('visibility_hidden');
+            }
+          });
+
+          win.addEventListener('pagehide', () => {
+            reportTimeOnPage('page_hide');
+          }, { once: true });
+
+          win.addEventListener('click', (event) => {
+            const target = event?.target;
+            const anchor = target?.closest?.('a');
+            if (!anchor || !anchor.href) return;
+            const linkUrl = anchor.href;
+            if (linkUrl.startsWith('mailto:') || linkUrl.startsWith('tel:') || linkUrl.startsWith('sms:')) {
+              return;
+            }
+            const currentHost = win?.location?.host;
+            const linkHost = anchor.host;
+            if (!currentHost || !linkHost || currentHost === linkHost) {
+              return;
+            }
+            const linkText = anchor.textContent?.trim();
+            trackEvent('outbound_click', {
+              link_url: linkUrl,
+              link_host: linkHost,
+              link_text: linkText ? linkText.slice(0, 120) : undefined,
+            });
+          }, { passive: true });
         })();`;
       })()}
     </script>
@@ -224,7 +313,7 @@ const gaId = site.analyticsId;
                 s.onerror = function() { console.log('GA blocked by ad blocker'); };
                 document.head.appendChild(s);
                 gtag('js', new Date());
-                gtag('config', GA_ID);
+                gtag('config', GA_ID, { send_page_view: false });
                 try {
                   if (window.appleAnalytics && typeof window.appleAnalytics.flushQueue === 'function') {
                     window.appleAnalytics.flushQueue();


### PR DESCRIPTION
### Motivation
- Replace WhatsApp CTAs with an SMS-based `Message Seller` experience and adjust copy/icon for clarity and accessibility.
- Ensure contact interactions are tracked consistently as `sms` contact actions in analytics.
- Improve GA/analytics payloads with richer page context so events are more actionable and reliable.
- Add lightweight behavioural signals (scroll depth, time-on-page, outbound clicks) to better understand engagement.

### Description
- Replaced the WhatsApp link with an `sms:` link in `src/components/QuickContactStrip.astro` and updated the CTA label to `Message Seller`.
- Added `smsHref`, updated icon, class (`--message`) and ARIA label in `src/components/StickyCTA.astro`, and switched tracking to `trackCtaInteraction('Message Seller', ..., 'sms', 'sticky-sms')` and `trackContact('sms', ...)`.
- Enhanced analytics bootstrap in `src/layouts/BaseLayout.astro` by adding `getPageContext()`, merging page context into every `trackEvent` payload, emitting an initial `page_view`, and adding handlers for scroll depth milestones, time-on-page (`time_on_page`), and outbound click events.
- Set `gtag('config', GA_ID, { send_page_view: false })` so page views are controlled by the site analytics wrapper and remain compliant with consent flow.

### Testing
- Ran the dev server with `npm run dev -- --host 0.0.0.0 --port 4321`; it failed due to an unresolved `virtual:pwa-register` dependency (dev server error).
- Attempted an automated Playwright screenshot of the homepage, but the script timed out because the site did not fully load.
- No additional automated test suite runs succeeded locally because the local dev environment did not fully start.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69516b914a5c8324866c081744e5d71e)