### PR TITLE
Update guide price to £250,000 and surface final-reduction messaging

### DIFF
--- a/site.config.ts
+++ b/site.config.ts
@@ -53,7 +53,7 @@ export const site = {
   address: 'Apple Cottage, Creetown, Scotland',
   coordinates: { lat: 54.899611, lng: -4.380458 },
   bookingUrl: 'https://tidycal.com/sidmustafa/apple-cottage-viewing',
-  price: '💰 New Guide Price £275,000 — recently reduced',
+  price: '💰 Final guide price £250,000 — international move secured',
   bedrooms: '🛏️ 3 Double Bedrooms',
   bathrooms: '🛁 1 + Downstairs WC',
   epc: '⚡ B - Energy Efficient',

--- a/src/components/Seo.astro
+++ b/src/components/Seo.astro
@@ -40,6 +40,6 @@ const image = site.ogImage || site.hero?.image || '/images/og-default.jpg';
       { '@type':'LocationFeatureSpecification', name: 'EV charger', value: 'Yes' },
       { '@type':'LocationFeatureSpecification', name: 'Solar PV + battery', value: 'Yes' }
     ],
-    offers: { '@type': 'Offer', price: 275000, priceCurrency: 'GBP' }
+    offers: { '@type': 'Offer', price: 250000, priceCurrency: 'GBP' }
   })}
 /> 

--- a/src/components/StickyCTA.astro
+++ b/src/components/StickyCTA.astro
@@ -143,6 +143,12 @@ const homeReportRel = homeReportIsExternal ? 'noopener' : undefined;
     color: #166534;
   }
 
+  .sticky-cta__chip--highlight {
+    background: #fff7ed;
+    color: #9a3412;
+    border: 1px solid rgba(234, 88, 12, 0.35);
+  }
+
   .sticky-cta__supporting {
     margin: 0;
     font-size: 0.9rem;
@@ -303,24 +309,27 @@ const homeReportRel = homeReportIsExternal ? 'noopener' : undefined;
   </button>
   <div class="sticky-cta__summary">
     <p class="sticky-cta__headline" id="sticky-cta-heading">
-      See the new guide price at Apple Cottage today
+      Final guide price now available at Apple Cottage
     </p>
     <div class="sticky-cta__meta">
       <span
         class="sticky-cta__price"
-        aria-label="Guide price two hundred seventy-five thousand pounds, recently reduced"
+        aria-label="Final guide price two hundred fifty thousand pounds, last reduction"
       >
-        <span class="sticky-cta__price-label">New guide price</span>
-        <span class="sticky-cta__price-figure">£275,000</span>
-        <span class="sticky-cta__price-note">Reduced to welcome more viewings</span>
+        <span class="sticky-cta__price-label">Final guide price</span>
+        <span class="sticky-cta__price-figure">£250,000</span>
+        <span class="sticky-cta__price-note">Final reduction to support an international move</span>
+      </span>
+      <span class="sticky-cta__chip sticky-cta__chip--highlight" aria-label="Final reduction">
+        Final reduction
       </span>
       <span class="sticky-cta__chip" aria-label="Energy performance certificate rating B">
         EPC B
       </span>
     </div>
     <p class="sticky-cta__supporting">
-      Just reduced to a £275,000 guide price — schedule a tour, download the home report or message the
-      owner instantly while diary space is open.
+      Final guide price set for a swift, straightforward sale — book a viewing, download the home report,
+      or message the owner while diary space is open.
     </p>
   </div>
   <div class="sticky-cta__actions">

--- a/src/components/TrustBar.astro
+++ b/src/components/TrustBar.astro
@@ -113,9 +113,10 @@ const homeReportAria = 'View property details and home report';
   <article class="trust-item">
     <span class="trust-icon" aria-hidden="true">📄</span>
     <div class="trust-copy">
-      <p class="trust-eyebrow">Independent Survey</p>
-      <p class="trust-title">Download the Home Report</p>
+      <p class="trust-eyebrow">Final Reduction</p>
+      <p class="trust-title">Guide Price £250,000</p>
       <p class="trust-description">
+        Final reduction to support our secured international move and enable a swift, straightforward sale.{' '}
         {hasHomeReportLink ? (
           <a
             class="trust-link"
@@ -125,10 +126,10 @@ const homeReportAria = 'View property details and home report';
             rel={homeReportRel}
             aria-label={homeReportAria}
           >
-            Guide Price £275,000 (recently reduced)
+            View the Home Report & valuation
           </a>
         ) : (
-          <span>Guide Price £275,000 (recently reduced)</span>
+          <span>Home Report available on request.</span>
         )}
       </p>
     </div>


### PR DESCRIPTION
### Motivation
- Finalise a price reduction to £250,000 to support a quick sale tied to an international move and make the change visible and reassuring in the UI and structured data.
- Present the reduction in a way that draws attention but avoids implying any defect or uncertainty about the property.

### Description
- Updated the public price label in `site.config.ts` to: `💰 Final guide price £250,000 — international move secured`.
- Updated structured data in `src/components/Seo.astro` to set the `offers.price` numeric value to `250000` (GBP) for accurate search engine feeds.
- Refreshed the trust bar (`src/components/TrustBar.astro`) to show a clear, positive “Final Reduction” message, change the title copy to `Guide Price £250,000`, and improve the home report link copy to `View the Home Report & valuation` while showing a fallback when the report is not present.
- Updated the sticky CTA (`src/components/StickyCTA.astro`) to use reassuring, eye-catching wording, add a highlighted chip (`.sticky-cta__chip--highlight`) and update ARIA price labels so the reduction is more prominent without negative tone.

### Testing
- Ran the pre-commit linting task (`eslint --fix`) as part of the commit hooks and it completed successfully.
- Started the dev server with `npm run dev`; the site served pages and a render was captured, though Vite reported an unresolved import for `virtual:pwa-register` during dev (non-blocking for the visual smoke test).
- Automated browser smoke test (Playwright) using Firefox captured a full-page screenshot at `artifacts/price-reduction-hero.png` to verify the updated hero / CTA content rendered as expected and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6967eae14a888324921fbab8dee149ae)