### PR TITLE
Refine pricing chip shape and add rotating laser ring animation

### DIFF
--- a/src/components/StickyCTA.astro
+++ b/src/components/StickyCTA.astro
@@ -101,14 +101,15 @@ const homeReportRel = homeReportIsExternal ? 'noopener' : undefined;
     display: inline-flex;
     align-items: flex-start;
     gap: 0.35rem;
-    padding: 0.6rem 0.75rem;
-    border-radius: 999px;
+    padding: 0.6rem 0.9rem;
+    border-radius: 0.95rem;
     font-size: 0.85rem;
     font-weight: 600;
     letter-spacing: 0.01em;
   }
 
   .sticky-cta__price {
+    position: relative;
     flex-direction: column;
     align-items: flex-start;
     background: linear-gradient(120deg, #0ea5e9 0%, #0f766e 40%, #16a34a 100%);
@@ -117,6 +118,43 @@ const homeReportRel = homeReportIsExternal ? 'noopener' : undefined;
     box-shadow: 0 8px 20px -8px rgba(14, 165, 233, 0.4);
     min-width: min(18rem, 100%);
     border: 1px solid rgba(236, 253, 243, 0.28);
+    border-radius: 1.1rem;
+    padding: 0.75rem 1.1rem;
+    line-height: 1.2;
+    overflow: visible;
+  }
+
+  .sticky-cta__price::before {
+    content: '';
+    position: absolute;
+    inset: -3px;
+    border-radius: inherit;
+    padding: 2px;
+    background: conic-gradient(
+      from 0deg,
+      rgba(56, 189, 248, 0),
+      rgba(56, 189, 248, 0.85),
+      rgba(45, 212, 191, 0.75),
+      rgba(34, 197, 94, 0.65),
+      rgba(56, 189, 248, 0)
+    );
+    -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    filter: drop-shadow(0 0 8px rgba(56, 189, 248, 0.5));
+    opacity: 0.9;
+    animation: sticky-cta-laser 4s linear infinite;
+    pointer-events: none;
+  }
+
+  .sticky-cta__price::after {
+    content: '';
+    position: absolute;
+    inset: -8px;
+    border-radius: inherit;
+    border: 1px solid rgba(56, 189, 248, 0.25);
+    opacity: 0.6;
+    pointer-events: none;
   }
 
   .sticky-cta__price-label {
@@ -128,13 +166,29 @@ const homeReportRel = homeReportIsExternal ? 'noopener' : undefined;
 
   .sticky-cta__price-figure {
     font-size: clamp(1.05rem, 2vw, 1.25rem);
-    line-height: 1.2;
+    line-height: 1.25;
   }
 
   .sticky-cta__price-note {
     font-size: 0.85rem;
     color: #e2f3eb;
     margin-top: 0.1rem;
+  }
+
+  @keyframes sticky-cta-laser {
+    from {
+      transform: rotate(0deg);
+    }
+
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .sticky-cta__price::before {
+      animation: none;
+    }
   }
 
   .sticky-cta__chip {


### PR DESCRIPTION
### Motivation
- Prevent the Builder radius from cutting off text in the pricing chip by switching away from an exaggerated "peel" shape to a more reliable rounded rectangle. 
- Add a subtle, high-contrast animated ring to draw attention to the final guide price while keeping accessibility in mind (reduced-motion support).

### Description
- Adjusted chip geometry and spacing by updating padding and `border-radius` values and increasing `line-height` to avoid clipping and improve legibility in `src/components/StickyCTA.astro`.
- Made the price container `position: relative`, exposed overflow, and increased internal padding to provide room for decorative effects.
- Added a rotating conic-gradient "laser" ring using `::before` and a faint outline using `::after`, plus a `@keyframes sticky-cta-laser` animation to rotate the ring and a subtle drop-shadow halo for glow.
- Implemented `@media (prefers-reduced-motion: reduce)` to disable the animation for users who prefer reduced motion.

### Testing
- Attempted to run the dev server with `npm run dev`, but Vite failed due to an unresolved dependency (`virtual:pwa-register`), causing the local build to error out.
- Attempted automated visual verification by running Playwright screenshots, but the browser run timed out / Chromium crashed (SIGSEGV), so screenshots could not be produced.
- No unit or snapshot tests were executed as part of this rollout (no automated tests succeeded against the changed component).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6967f5503a5c8324910ea8d4efd1eedf)